### PR TITLE
Added League Highlight, Gwennen unique fix and minor augments

### DIFF
--- a/Ninja Price/Main/CustomItem.cs
+++ b/Ninja Price/Main/CustomItem.cs
@@ -342,26 +342,59 @@ public class CustomItem
             }
             else
             {
-                switch (Rarity) // Unique information
+                if (IsCorrupted)
                 {
-                    case ItemRarity.Unique or ItemRarity.Normal when ClassName is "Amulet" or "Ring" or "Belt":
+                    // Handle corrupted items
+                    if (ClassName == "Amulet" || ClassName == "Ring" || ClassName == "Belt")
+                    {
                         ItemType = ItemTypes.UniqueAccessory;
-                        break;
-                    case ItemRarity.Unique or ItemRarity.Normal when itemEntity.HasComponent<Armour>() || ClassName == "Quiver":
+                    }
+                    else if (itemEntity.HasComponent<Armour>() || ClassName == "Quiver")
+                    {
                         ItemType = ItemTypes.UniqueArmour;
-                        break;
-                    case ItemRarity.Unique when itemEntity.HasComponent<Flask>():
-                        ItemType = ItemTypes.UniqueFlask;
-                        break;
-                    case ItemRarity.Unique or ItemRarity.Normal when ClassName == "Jewel":
+                    }
+
+                    else if (ClassName == "Jewel")
+                    {
                         ItemType = ItemTypes.UniqueJewel;
-                        break;
-                    case ItemRarity.Unique when MapInfo.IsMap:
-                        ItemType = ItemTypes.UniqueMap;
-                        break;
-                    case ItemRarity.Unique or ItemRarity.Normal when itemEntity.HasComponent<Weapon>():
+                    }
+
+                    else if (itemEntity.HasComponent<Weapon>())
+                    {
                         ItemType = ItemTypes.UniqueWeapon;
-                        break;
+                    }
+                    else
+                    {
+                        // Handle other cases or do nothing
+                    }
+                }
+                else
+                {
+                    switch (Rarity) // Unique information
+                    {
+                        case ItemRarity.Unique or ItemRarity.Normal when (ClassName == "Amulet" || ClassName == "Ring" || ClassName == "Belt"):
+                            ItemType = ItemTypes.UniqueAccessory;
+                            break;
+                        case ItemRarity.Unique or ItemRarity.Normal when (itemEntity.HasComponent<Armour>() || ClassName == "Quiver"):
+                            ItemType = ItemTypes.UniqueArmour;
+                            break;
+                        case ItemRarity.Unique when itemEntity.HasComponent<Flask>():
+                            ItemType = ItemTypes.UniqueFlask;
+                            break;
+                        case ItemRarity.Unique or ItemRarity.Normal when ClassName == "Jewel":
+                            ItemType = ItemTypes.UniqueJewel;
+                            break;
+                        case ItemRarity.Unique when MapInfo.IsMap:
+                            ItemType = ItemTypes.UniqueMap;
+                            break;
+                        case ItemRarity.Unique or ItemRarity.Normal when itemEntity.HasComponent<Weapon>():
+                            ItemType = ItemTypes.UniqueWeapon;
+                            break;
+                        default:
+                            // Handle other cases or do nothing
+                            break;
+                    }
+
                 }
             }
         }

--- a/Ninja Price/Main/ItemData.cs
+++ b/Ninja Price/Main/ItemData.cs
@@ -1,0 +1,17 @@
+﻿namespace Ninja_Price.Main
+{
+    public class ItemData
+    {
+        public string BaseItem { get; set; }
+        public double Chance { get; set; }
+        public int AverageOrbs { get; set; }
+        public double DestructionChance { get; set; }
+        public string BaseItemDisambiguation { get; set; }
+        public string Tier { get; set; }
+        public string Name { get; set; }
+        public string Disambiguation { get; set; }
+        public int MinILvl { get; set; }
+        public double Weight { get; set; }
+        public string PoeWikiLink { get; set; }
+    }
+}

--- a/Ninja Price/Main/Main.cs
+++ b/Ninja Price/Main/Main.cs
@@ -1,6 +1,7 @@
 ﻿using ExileCore;
 using ExileCore.PoEMemory.FilesInMemory;
 using ExileCore.PoEMemory.MemoryObjects;
+using Microsoft.VisualBasic.FileIO;
 using Newtonsoft.Json;
 using Ninja_Price.API.PoeNinja.Classes;
 using System;
@@ -20,8 +21,10 @@ public partial class Main : BaseSettingsPlugin<Settings.Settings>
     private const string PoeLeagueApiList = "http://api.pathofexile.com/leagues?type=main&compact=1";
     private const string CustomUniqueArtMappingPath = "uniqueArtMapping.json";
     private const string DefaultUniqueArtMappingPath = "uniqueArtMapping.default.json";
+    private const string ItemDataCSVPath = "tainted_mythic_orb_outcomes.csv";
     private int _updating;
     public Dictionary<string, List<string>> UniqueArtMapping = new Dictionary<string, List<string>>();
+    public List<ItemData> csvItemData;
     private readonly ConcurrentDictionary<NecropolisCraftingMod, string> _necropolisModText = [];
 
     [GeneratedRegex("<[^>]*>{{(?<data>[^}]*)}}")]
@@ -51,6 +54,12 @@ public partial class Main : BaseSettingsPlugin<Settings.Settings>
         };
         Settings.DataSourceSettings.SyncCurrentLeague.OnValueChanged += (_, _) => SyncCurrentLeague();
         CustomItem.InitCustomItem(this);
+
+        csvItemData = ReadItemDataCsvFile();
+        //   foreach (var item in items)
+        //{
+        //   LogMessage($"Base Item: {item.BaseItem}, Chance: {item.Chance}, Average Orbs: {item.AverageOrbs}, Destruction Chance: {item.DestructionChance}, Base Item Disambiguation: {item.BaseItemDisambiguation}, Tier: {item.Tier}, Name: {item.Name}, Disambiguation: {item.Disambiguation}, Min ILvl: {item.MinILvl}, Weight: {item.Weight}, PoeWikiLink: {item.PoeWikiLink}",5);
+        //}
 
         GameController.PluginBridge.SaveMethod("NinjaPrice.GetValue", (Entity e) =>
         {
@@ -215,5 +224,88 @@ public partial class Main : BaseSettingsPlugin<Settings.Settings>
 
             return playerLeague;
         }
+    }
+    private double ParsePercentage(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return 0;
+
+        // Remove '%' character and convert to double
+        if (double.TryParse(value.Replace("%", ""), out double result))
+            return result / 100;
+        else
+            return 0;
+    }
+    static int ParseInt(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return 0;
+
+        int parsedValue;
+        if (int.TryParse(value, out parsedValue))
+            return parsedValue;
+        else
+            return 0;
+    }
+
+    static double ParseDouble(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return 0;
+
+        double parsedValue;
+        if (double.TryParse(value, out parsedValue))
+            return parsedValue;
+        else
+            return 0;
+    }
+
+    private List<ItemData> ReadItemDataCsvFile()
+    {
+        List<ItemData> items = new List<ItemData>();
+
+        var filePath = Path.Join(DirectoryFullName, ItemDataCSVPath);
+
+
+
+        if (!File.Exists(filePath))
+        {
+            LogError("Item data CSV File not found at " + filePath);
+            return items;
+        }
+
+        using (TextFieldParser parser = new TextFieldParser(filePath))
+        {
+            parser.TextFieldType = FieldType.Delimited;
+            parser.SetDelimiters(",");
+
+            parser.ReadLine();
+
+            while (!parser.EndOfData)
+            {
+                string[] fields = parser.ReadFields();
+                if (fields != null)
+                {
+                    ItemData item = new ItemData
+                    {
+                        BaseItem = fields[0],
+                        Chance = ParsePercentage(fields[1]),
+                        AverageOrbs = ParseInt(fields[2]),
+                        DestructionChance = ParsePercentage(fields[3]),
+                        BaseItemDisambiguation = fields[4],
+                        Tier = fields[5],
+                        Name = fields[6],
+                        Disambiguation = fields[7],
+                        MinILvl = ParseInt(fields[8]),
+                        Weight = ParseDouble(fields[9]),
+                        PoeWikiLink = fields[10]
+                    };
+
+                    items.Add(item);
+                }
+            }
+        }
+
+        return items;
     }
 }

--- a/Ninja Price/Main/Render.cs
+++ b/Ninja Price/Main/Render.cs
@@ -516,14 +516,13 @@ public partial class Main
         var valueToShow = item.PriceData.MinChaosValue;        
         if (RitualPanel.IsVisible)
         {
-            if (TryGetTributePrice(item, out var amount))
+            drawBox.Y += 13; // drawbox on Rituals seems a bit off due to using the item rect and not the window item rect itself
+            drawBox.X += 13; //move slightly to the right so we can see stack number
+            drawBox.Width -= 13; //to compensate moving
+            if (TryGetTributePrice(item, out var amount) && Settings.LeagueSpecificSettings.ShowCostPer1000Tribute)
             {
                 var auxvalueToShow = amount.ToString();
-                valueToShow = (valueToShow / amount)*1000;
-
-                drawBox.Y +=13; // drawbox on Rituals seems a bit off due to using the item rect and not the window item rect itself
-                drawBox.X += 13; //move slightly to the right so we can see stack number
-                drawBox.Width -= 13; //to compensate moving
+                valueToShow = (valueToShow / amount)*1000;                
                 if (valueToShow > Settings.LeagueHighlight.RitualThrehsold)
                     auxColor = Settings.LeagueHighlight.HighlightColor;
             }

--- a/Ninja Price/Methods/Methods.cs
+++ b/Ninja Price/Methods/Methods.cs
@@ -613,7 +613,7 @@ public partial class Main
             switch (item.ItemType) // easier to get data for each item type and handle logic based on that
             {
                 case ItemTypes.UniqueArmour:
-                    var uniqueArmourSearch = CollectedData.UniqueArmours.Lines.FindAll(x => x.BaseType == item.BaseName && x.IsChanceable() && (x.Links < 5 || x.Links == null));
+                    var uniqueArmourSearch = CollectedData.UniqueArmours.Lines.FindAll(x => x.BaseType == item.BaseName && x.IsChanceable() && csvItemData.Any(csvitem => csvitem.Name == x.Name) && (x.Links < 5 || x.Links == null));
                     if (uniqueArmourSearch.Count > 0)
                     {
                         foreach (var result in uniqueArmourSearch)
@@ -623,7 +623,7 @@ public partial class Main
                     }
                     break;
                 case ItemTypes.UniqueWeapon:
-                    var uniqueWeaponSearch = CollectedData.UniqueWeapons.Lines.FindAll(x => x.BaseType == item.BaseName && x.IsChanceable() && (x.Links < 5 || x.Links == null));
+                    var uniqueWeaponSearch = CollectedData.UniqueWeapons.Lines.FindAll(x => x.BaseType == item.BaseName && x.IsChanceable() && csvItemData.Any(csvitem => csvitem.Name == x.Name) && (x.Links < 5 || x.Links == null));
                     if (uniqueWeaponSearch.Count > 0)
                     {
                         foreach (var result in uniqueWeaponSearch)
@@ -633,7 +633,7 @@ public partial class Main
                     }
                     break;
                 case ItemTypes.UniqueAccessory:
-                    var uniqueAccessorySearch = CollectedData.UniqueAccessories.Lines.FindAll(x => x.BaseType == item.BaseName && x.IsChanceable());
+                    var uniqueAccessorySearch = CollectedData.UniqueAccessories.Lines.FindAll(x => x.BaseType == item.BaseName && x.IsChanceable() && csvItemData.Any(csvitem => csvitem.Name == x.Name));
                     if (uniqueAccessorySearch.Count > 0)
                     {
                         foreach (var result in uniqueAccessorySearch)
@@ -643,7 +643,7 @@ public partial class Main
                     }
                     break;
                 case ItemTypes.UniqueJewel:
-                    var uniqueJewelSearch = CollectedData.UniqueJewels.Lines.FindAll(x => x.DetailsId.Contains(item.BaseName.ToLower().Replace(" ", "-")) && x.IsChanceable());
+                    var uniqueJewelSearch = CollectedData.UniqueJewels.Lines.FindAll(x => x.DetailsId.Contains(item.BaseName.ToLower().Replace(" ", "-")) && x.IsChanceable() && csvItemData.Any(csvitem => csvitem.Name == x.Name));
                     if (uniqueJewelSearch.Count > 0)
                     {
                         foreach (var result in uniqueJewelSearch)
@@ -730,4 +730,5 @@ public partial class Main
         if (Settings.EnableDebugLogging) LogMessage($"{GetCurrentMethod()}.ShouldUpdateValuesInventory() == True", 5, Color.LimeGreen);
         return true;
     }
+
 }

--- a/Ninja Price/Ninja Price.csproj
+++ b/Ninja Price/Ninja Price.csproj
@@ -13,6 +13,10 @@
     <EmbeddedResource Include="uniqueArtMapping.default.json" LogicalName="uniqueArtMapping.default.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
+    <None Remove="tainted_mythic_orb_outcomes.csv" />
+    <Content Include="tainted_mythic_orb_outcomes.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="ExileCore">

--- a/Ninja Price/Settings/Settings.cs
+++ b/Ninja Price/Settings/Settings.cs
@@ -19,6 +19,7 @@ public class Settings : ISettings
     public HoveredItemSettings HoveredItemSettings { get; set; } = new();
     public PriceOverlaySettings PriceOverlaySettings { get; set; } = new();
     public LeagueSpecificSettings LeagueSpecificSettings { get; set; } = new();
+    public LeagueHighlight LeagueHighlight { get; set; } = new();
     public VisualPriceSettings VisualPriceSettings { get; set; } = new();
     public ToggleNode Enable { get; set; } = new(true);
 }
@@ -59,8 +60,23 @@ public class LeagueSpecificSettings
 
     [Menu("Artifact Chaos Prices", "Display chaos equivalent price for items with artifact costs", 7)]
     public ToggleNode ShowArtifactChaosPrices { get; set; } = new(true);
+    public ToggleNode ShowUniquesGamble { get; set; } = new(true);
 }
+[Submenu(CollapsedByDefault = true)]
+public class LeagueHighlight
+{
+    public RangeNode<float> ExceptionalBlackScytheThreshold { get; set; } = new(5f, 0, 25);
 
+    public RangeNode<float> GrandBlackScytheThreshold { get; set; } = new(1.80f, 0, 5);
+
+    public RangeNode<float> GreaterBlackScytheThreshold { get; set; } = new(1.40f, 0, 5);
+
+    public RangeNode<float> LesserBlackScytheThreshold { get; set; } = new(1.25f, 0, 5);
+
+    public RangeNode<int> GwennenChaosCutoff { get; set; } = new(0, 15, 200);
+    public RangeNode<float> RitualThrehsold { get; set; } = new(1.0f, 0, 5);
+    public ColorNode HighlightColor { get; set; } = new Color(0, 150, 0, 255);
+}
 [Submenu(CollapsedByDefault = true)]
 public class InventoryValueSettings
 {

--- a/Ninja Price/Settings/Settings.cs
+++ b/Ninja Price/Settings/Settings.cs
@@ -61,6 +61,8 @@ public class LeagueSpecificSettings
     [Menu("Artifact Chaos Prices", "Display chaos equivalent price for items with artifact costs", 7)]
     public ToggleNode ShowArtifactChaosPrices { get; set; } = new(true);
     public ToggleNode ShowUniquesGamble { get; set; } = new(true);
+    [Menu(null, "Assumes 1000 tribute is equal to 1 chaos, if enabled shows value against this baseline")]
+    public ToggleNode ShowCostPer1000Tribute { get; set; } = new(true);
 }
 [Submenu(CollapsedByDefault = true)]
 public class LeagueHighlight
@@ -73,7 +75,7 @@ public class LeagueHighlight
 
     public RangeNode<float> LesserBlackScytheThreshold { get; set; } = new(1.25f, 0, 5);
 
-    public RangeNode<int> GwennenChaosCutoff { get; set; } = new(0, 15, 200);
+    public RangeNode<int> GwennenChaosCutoff { get; set; } = new(15, 0, 200);
     public RangeNode<float> RitualThrehsold { get; set; } = new(1.0f, 0, 5);
     public ColorNode HighlightColor { get; set; } = new Color(0, 150, 0, 255);
 }

--- a/Ninja Price/tainted_mythic_orb_outcomes.csv
+++ b/Ninja Price/tainted_mythic_orb_outcomes.csv
@@ -1,0 +1,584 @@
+baseItem,chance,averageOrbs,destructionChance,baseItemDisambiguation,tier,name,disambiguation,minILvl,weight,poeWikiLink
+Abyssal Axe,7.87%,13,92.13%,,3,Ngamahu's Flame,,,314.8,https://www.poewiki.net/wiki/Ngamahu%27s_Flame
+Agate Amulet,0.48%,211,50.00%,,2,Voll's Devotion,,,55.6,https://www.poewiki.net/wiki/Voll%27s_Devotion
+Agate Amulet,14.00%,8,50.00%,,4,The Aylardex,,,1637.3,https://www.poewiki.net/wiki/The_Aylardex
+Agate Amulet,17.76%,6,50.00%,,5,Shaper's Seed,,,2076.4,https://www.poewiki.net/wiki/Shaper%27s_Seed
+Agate Amulet,17.76%,6,50.00%,,5,Extractor Mentis,,,2076.4,https://www.poewiki.net/wiki/Extractor_Mentis
+Amber Amulet,22.04%,5,50.00%,,4,Bloodsoaked Medallion,,,1637.3,https://www.poewiki.net/wiki/Bloodsoaked_Medallion
+Amber Amulet,27.96%,4,50.00%,,5,The Anvil,,,2076.4,https://www.poewiki.net/wiki/The_Anvil
+Ambush Mitts,40.93%,3,59.07%,,4,Stormseeker,,,1637.3,https://www.poewiki.net/wiki/Stormseeker
+Ambusher,25.00%,4,50.00%,,5,Goblinedge,,,2076.4,https://www.poewiki.net/wiki/Goblinedge
+Ambusher,25.00%,4,50.00%,,5,Taproot,,,2076.4,https://www.poewiki.net/wiki/Taproot
+Amethyst Ring,1.39%,72,90.74%,,2,Death Rush,,,55.6,https://www.poewiki.net/wiki/Death_Rush
+Amethyst Ring,7.87%,13,90.74%,,3,Ming's Heart,,,314.8,https://www.poewiki.net/wiki/Ming%27s_Heart
+Ancient Greaves,40.93%,3,59.07%,,4,Kahuturoa's Certainty,,,1637.3,https://www.poewiki.net/wiki/Kahuturoa%27s_Certainty
+Ancient Spirit Shield,40.93%,3,59.07%,,4,Kongming's Stratagem,,,1637.3,https://www.poewiki.net/wiki/Kongming%27s_Stratagem
+Antique Greaves,50.00%,2,50.00%,,5,Torchoak Step,,,2076.4,https://www.poewiki.net/wiki/Torchoak_Step
+Antique Rapier,50.00%,2,50.00%,,5,Ewar's Mirage,,,2076.4,https://www.poewiki.net/wiki/Ewar%27s_Mirage
+Arcanist Gloves,7.87%,13,92.13%,,3,Grip of the Council,,,314.8,https://www.poewiki.net/wiki/Grip_of_the_Council
+Arcanist Slippers,7.87%,13,92.13%,,3,Inya's Epiphany,,,314.8,https://www.poewiki.net/wiki/Inya%27s_Epiphany
+Archon Kite Shield,1.39%,72,98.61%,,2,Prism Guardian,,,55.6,https://www.poewiki.net/wiki/Prism_Guardian
+Assassin Bow,1.30%,77,50.00%,,2,Darkscorn,,,55.6,https://www.poewiki.net/wiki/Darkscorn
+Assassin Bow,48.70%,3,50.00%,,5,Chin Sol,,,2076.4,https://www.poewiki.net/wiki/Chin_Sol
+Assassin's Garb,7.87%,13,92.13%,,3,Cospri's Will,,,314.8,https://www.poewiki.net/wiki/Cospri%27s_Will
+Assassin's Mitts,7.87%,13,51.20%,,3,Storm's Gift,,,314.8,https://www.poewiki.net/wiki/Storm%27s_Gift
+Assassin's Mitts,40.93%,3,51.20%,,4,Snakebite,,,1637.3,https://www.poewiki.net/wiki/Snakebite
+Astral Plate,7.87%,13,84.26%,,3,Blunderbore,,,314.8,https://www.poewiki.net/wiki/Blunderbore
+Astral Plate,7.87%,13,84.26%,,3,Death's Oath,,,314.8,https://www.poewiki.net/wiki/Death%27s_Oath
+Auric Mace,50.00%,2,50.00%,,5,Callinellus Malleus,,,2076.4,https://www.poewiki.net/wiki/Callinellus_Malleus
+Aventail Helmet,50.00%,2,50.00%,,5,Mindspiral,,,2076.4,https://www.poewiki.net/wiki/Mindspiral
+Awl,50.00%,2,50.00%,,5,Wildslash,,,2076.4,https://www.poewiki.net/wiki/Wildslash
+Barbute Helmet,50.00%,2,50.00%,,5,Thrillsteel,,,2076.4,https://www.poewiki.net/wiki/Thrillsteel
+Baroque Round Shield,7.87%,13,92.13%,,3,Daresso's Courage,,,314.8,https://www.poewiki.net/wiki/Daresso%27s_Courage
+Basket Rapier,50.00%,2,50.00%,,5,Aurumvorax,,,2076.4,https://www.poewiki.net/wiki/Aurumvorax
+Bastard Sword,50.00%,2,50.00%,,5,Shiversting,,,2076.4,https://www.poewiki.net/wiki/Shiversting
+Blazing Arrow Quiver,50.00%,2,50.00%,,5,Blackgleam,,,2076.4,https://www.poewiki.net/wiki/Blackgleam
+Blue Pearl Amulet,7.87%,13,92.13%,,3,Gloomfang,,,314.8,https://www.poewiki.net/wiki/Gloomfang
+Blunt Arrow Quiver,40.93%,3,59.07%,,4,Rearguard,,,1637.3,https://www.poewiki.net/wiki/Rearguard
+Bone Armour,40.93%,3,59.07%,,4,Bloodbond,,,1637.3,https://www.poewiki.net/wiki/Bloodbond
+Bone Helmet,40.93%,3,59.07%,,4,Ancient Skull,,,1637.3,https://www.poewiki.net/wiki/Ancient_Skull
+Boot Blade,50.00%,2,50.00%,,5,Widowmaker,,,2076.4,https://www.poewiki.net/wiki/Widowmaker
+Boot Knife,50.00%,2,50.00%,,5,Ungil's Gauche,,,2076.4,https://www.poewiki.net/wiki/Ungil%27s_Gauche
+Branded Kite Shield,7.87%,13,92.13%,,3,Saffell's Frame,,,314.8,https://www.poewiki.net/wiki/Saffell%27s_Frame
+Brass Maul,50.00%,2,50.00%,,5,Geofri's Baptism,,,2076.4,https://www.poewiki.net/wiki/Geofri%27s_Baptism
+Brass Spirit Shield,40.93%,3,59.07%,,4,Sentari's Answer,,,1637.3,https://www.poewiki.net/wiki/Sentari%27s_Answer
+Bronze Gauntlets,50.00%,2,50.00%,,5,Giantsbane,,,2076.4,https://www.poewiki.net/wiki/Giantsbane
+Bronze Sceptre,50.00%,2,50.00%,,5,Axiom Perpetuum,,,2076.4,https://www.poewiki.net/wiki/Axiom_Perpetuum
+Bronzescale Boots,40.93%,3,59.07%,,4,Lioneye's Paws,,,1637.3,https://www.poewiki.net/wiki/Lioneye%27s_Paws
+Bronzescale Gauntlets,6.58%,16,50.00%,,3,Vaal Caress,,,314.8,https://www.poewiki.net/wiki/Vaal_Caress
+Bronzescale Gauntlets,43.42%,3,50.00%,,5,Slitherpinch,,,2076.4,https://www.poewiki.net/wiki/Slitherpinch
+Buckskin Tunic,40.93%,3,59.07%,,4,Ashrend,,,1637.3,https://www.poewiki.net/wiki/Ashrend
+Callous Mask,40.93%,3,59.07%,,4,Eye of Malice,,,1637.3,https://www.poewiki.net/wiki/Eye_of_Malice
+Carnal Armour,50.00%,2,50.00%,,5,The Restless Ward,,,2076.4,https://www.poewiki.net/wiki/The_Restless_Ward
+Carnal Boots,1.39%,72,98.61%,,2,Corpsewalker,,,55.6,https://www.poewiki.net/wiki/Corpsewalker
+Carnal Mitts,22.04%,5,50.00%,,4,Algor Mortis,,,1637.3,https://www.poewiki.net/wiki/Algor_Mortis
+Carnal Mitts,27.96%,4,50.00%,,5,The Embalmer,,,2076.4,https://www.poewiki.net/wiki/The_Embalmer
+Carnal Sceptre,40.93%,3,59.07%,,4,Breath of the Council,,,1637.3,https://www.poewiki.net/wiki/Breath_of_the_Council
+Carved Wand,1.39%,72,57.68%,,2,The Poet's Pen,,,55.6,https://www.poewiki.net/wiki/The_Poet%27s_Pen
+Carved Wand,40.93%,3,57.68%,,4,Ashcaller,,,1637.3,https://www.poewiki.net/wiki/Ashcaller
+Cedar Tower Shield,40.93%,3,59.07%,,4,Trolltimber Spire,,,1637.3,https://www.poewiki.net/wiki/Trolltimber_Spire
+Chain Belt,11.02%,10,50.00%,,4,Ascent From Flesh,,,1637.3,https://www.poewiki.net/wiki/Ascent_From_Flesh
+Chain Belt,11.02%,10,50.00%,,4,Maligaro's Restraint,,,1637.3,https://www.poewiki.net/wiki/Maligaro%27s_Restraint
+Chain Belt,13.98%,8,50.00%,,5,Chain of Endurance,,,2076.4,https://www.poewiki.net/wiki/Chain_of_Endurance
+Chain Belt,13.98%,8,50.00%,,5,Bated Breath,,,2076.4,https://www.poewiki.net/wiki/Bated_Breath
+Chain Gloves,40.93%,3,59.07%,,4,Shackles of the Wretched,,,1637.3,https://www.poewiki.net/wiki/Shackles_of_the_Wretched
+Champion Kite Shield,1.39%,72,98.61%,,2,Aegis Aurora,,,55.6,https://www.poewiki.net/wiki/Aegis_Aurora
+Chiming Spirit Shield,50.00%,2,50.00%,,5,The Eternal Apple,,,2076.4,https://www.poewiki.net/wiki/The_Eternal_Apple
+Citrine Amulet,2.41%,42,50.00%,,3,The Jinxed Juju,,,314.8,https://www.poewiki.net/wiki/The_Jinxed_Juju
+Citrine Amulet,15.87%,7,50.00%,,5,Retaliation Charm,,,2076.4,https://www.poewiki.net/wiki/Retaliation_Charm
+Citrine Amulet,15.87%,7,50.00%,,5,Eye of Innocence,,,2076.4,https://www.poewiki.net/wiki/Eye_of_Innocence
+Citrine Amulet,15.87%,7,50.00%,,5,Daresso's Salute,,,2076.4,https://www.poewiki.net/wiki/Daresso%27s_Salute
+Clasped Boots,50.00%,2,50.00%,,5,Sundance,,,2076.4,https://www.poewiki.net/wiki/Sundance
+Clasped Mitts,25.00%,4,50.00%,,4,Shadows and Dust,,,1637.3,https://www.poewiki.net/wiki/Shadows_and_Dust
+Clasped Mitts,25.00%,4,50.00%,,4,Aukuna's Will,,,1637.3,https://www.poewiki.net/wiki/Aukuna%27s_Will
+Cleaver,50.00%,2,50.00%,,5,Dreadarc,,,2076.4,https://www.poewiki.net/wiki/Dreadarc
+Close Helmet,40.93%,3,59.07%,,4,The Baron,,,1637.3,https://www.poewiki.net/wiki/The_Baron
+Cloth Belt,0.41%,245,50.00%,,2,Sunblast,,,55.6,https://www.poewiki.net/wiki/Sunblast
+Cloth Belt,2.32%,44,50.00%,,3,Soulthirst,,,314.8,https://www.poewiki.net/wiki/Soulthirst
+Cloth Belt,2.32%,44,50.00%,,3,Bound Fate,,,314.8,https://www.poewiki.net/wiki/Bound_Fate
+Cloth Belt,2.32%,44,50.00%,,3,Soul Tether,,,314.8,https://www.poewiki.net/wiki/Soul_Tether
+Cloth Belt,12.06%,9,50.00%,,4,Ceinture of Benevolence,,,1637.3,https://www.poewiki.net/wiki/Ceinture_of_Benevolence
+Cloth Belt,15.29%,7,50.00%,,5,The Druggery,,,2076.4,https://www.poewiki.net/wiki/The_Druggery
+Cloth Belt,15.29%,7,50.00%,,5,Perandus Blazon,,,2076.4,https://www.poewiki.net/wiki/Perandus_Blazon
+Cobalt Jewel,1.39%,72,95.83%,,2,Witchbane,,,55.6,https://www.poewiki.net/wiki/Witchbane
+Cobalt Jewel,1.39%,72,95.83%,,2,Unending Hunger,,,55.6,https://www.poewiki.net/wiki/Unending_Hunger
+Cobalt Jewel,1.39%,72,95.83%,,2,Dead Reckoning,,,55.6,https://www.poewiki.net/wiki/Dead_Reckoning
+Colossal Tower Shield,40.93%,3,59.07%,,4,Ahn's Heritage,,,1637.3,https://www.poewiki.net/wiki/Ahn%27s_Heritage
+Colosseum Plate,1.39%,72,98.61%,,2,Pragmatism,,,55.6,https://www.poewiki.net/wiki/Pragmatism
+Compound Spiked Shield,50.00%,2,50.00%,,5,Maligaro's Lens,,,2076.4,https://www.poewiki.net/wiki/Maligaro%27s_Lens
+Conjurer Boots,7.87%,13,92.13%,,3,Rainbowstride,,,314.8,https://www.poewiki.net/wiki/Rainbowstride
+Conjurer Gloves,40.93%,3,59.07%,,4,Voidbringer,,,1637.3,https://www.poewiki.net/wiki/Voidbringer
+Conquest Chainmail,50.00%,2,50.00%,,5,Kingsguard,,,2076.4,https://www.poewiki.net/wiki/Kingsguard
+Copper Plate,40.93%,3,59.07%,,4,Solaris Lorica,,,1637.3,https://www.poewiki.net/wiki/Solaris_Lorica
+Coral Amulet,2.45%,41,50.00%,,3,Tainted Pact,,,314.8,https://www.poewiki.net/wiki/Tainted_Pact
+Coral Amulet,2.45%,41,50.00%,,3,Tavukai,,,314.8,https://www.poewiki.net/wiki/Tavukai
+Coral Amulet,12.75%,8,50.00%,,4,The Primordial Chain,,,1637.3,https://www.poewiki.net/wiki/The_Primordial_Chain
+Coral Amulet,16.17%,7,50.00%,,5,Araku Tiki,,,2076.4,https://www.poewiki.net/wiki/Araku_Tiki
+Coral Amulet,16.17%,7,50.00%,,5,Ikiaho's Promise,,,2076.4,https://www.poewiki.net/wiki/Ikiaho%27s_Promise
+Coral Ring,3.91%,26,50.00%,,3,Winterweave,,,314.8,https://www.poewiki.net/wiki/Winterweave
+Coral Ring,20.32%,5,50.00%,,4,Kaom's Sign,,,1637.3,https://www.poewiki.net/wiki/Kaom%27s_Sign
+Coral Ring,25.77%,4,50.00%,,5,Sibyl's Lament,,,2076.4,https://www.poewiki.net/wiki/Sibyl%27s_Lament
+Corrugated Buckler,40.93%,3,59.07%,,4,Great Old One's Ward,,,1637.3,https://www.poewiki.net/wiki/Great_Old_One%27s_Ward
+Corsair Sword,40.93%,3,59.07%,,4,Ichimonji,,,1637.3,https://www.poewiki.net/wiki/Ichimonji
+Crimson Jewel,1.39%,72,93.05%,,2,Might of the Meek,,,55.6,https://www.poewiki.net/wiki/Might_of_the_Meek
+Crimson Jewel,1.39%,72,93.05%,,2,Firesong,,,55.6,https://www.poewiki.net/wiki/Firesong
+Crimson Jewel,1.39%,72,93.05%,,2,Bloodnotch,,,55.6,https://www.poewiki.net/wiki/Bloodnotch
+Crimson Jewel,1.39%,72,93.05%,,2,Immutable Force,,,55.6,https://www.poewiki.net/wiki/Immutable_Force
+Crimson Jewel,1.39%,72,93.05%,,2,Inspired Learning,,,55.6,https://www.poewiki.net/wiki/Inspired_Learning
+Crude Bow,6.58%,16,50.00%,,3,Widowhail,,,314.8,https://www.poewiki.net/wiki/Widowhail
+Crude Bow,43.42%,3,50.00%,,5,Silverbranch,,,2076.4,https://www.poewiki.net/wiki/Silverbranch
+Crusader Chainmail,40.93%,3,59.07%,,4,Ambu's Charge,,,1637.3,https://www.poewiki.net/wiki/Ambu%27s_Charge
+Crusader Gloves,7.87%,13,92.13%,,3,Repentance,,,314.8,https://www.poewiki.net/wiki/Repentance
+Crusader Plate,1.39%,72,57.68%,,2,The Iron Fortress,,,55.6,https://www.poewiki.net/wiki/The_Iron_Fortress
+Crusader Plate,40.93%,3,57.68%,,4,Lioneye's Vision,,,1637.3,https://www.poewiki.net/wiki/Lioneye%27s_Vision
+Crystal Belt,7.87%,13,92.13%,,3,Auxium,,,314.8,https://www.poewiki.net/wiki/Auxium
+Crystal Sceptre,7.87%,13,84.26%,,3,Nycta's Lantern,,,314.8,https://www.poewiki.net/wiki/Nycta%27s_Lantern
+Crystal Sceptre,7.87%,13,84.26%,,3,The Supreme Truth,,,314.8,https://www.poewiki.net/wiki/The_Supreme_Truth
+Cutthroat's Garb,40.93%,3,59.07%,,4,Bronn's Lithe,,,1637.3,https://www.poewiki.net/wiki/Bronn%27s_Lithe
+Death Bow,7.87%,13,51.20%,,3,Death's Harp,,,314.8,https://www.poewiki.net/wiki/Death%27s_Harp
+Death Bow,40.93%,3,51.20%,,4,Iron Commander,,,1637.3,https://www.poewiki.net/wiki/Iron_Commander
+Decimation Bow,50.00%,2,50.00%,,5,Infractem,,,2076.4,https://www.poewiki.net/wiki/Infractem
+Decorative Axe,50.00%,2,50.00%,,5,Relentless Fury,,,2076.4,https://www.poewiki.net/wiki/Relentless_Fury
+Deerskin Boots,50.00%,2,50.00%,,5,Deerstalker,,,2076.4,https://www.poewiki.net/wiki/Deerstalker
+Deerskin Gloves,7.87%,13,92.13%,,3,Maligaro's Virtuosity,,,314.8,https://www.poewiki.net/wiki/Maligaro%27s_Virtuosity
+Deicide Mask,1.39%,72,98.61%,,2,Heretic's Veil,,,55.6,https://www.poewiki.net/wiki/Heretic%27s_Veil
+Demon Dagger,7.87%,13,92.13%,,3,Vulconus,,,314.8,https://www.poewiki.net/wiki/Vulconus
+Desert Brigandine,7.87%,13,92.13%,,3,Lightning Coil,,,314.8,https://www.poewiki.net/wiki/Lightning_Coil
+Despot Axe,50.00%,2,50.00%,,5,Debeon's Dirge,,,2076.4,https://www.poewiki.net/wiki/Debeon%27s_Dirge
+Destiny Leather,7.87%,13,92.13%,,3,Queen of the Forest,,,314.8,https://www.poewiki.net/wiki/Queen_of_the_Forest
+Destroyer Regalia,40.93%,3,59.07%,,4,The Coming Calamity,,,1637.3,https://www.poewiki.net/wiki/The_Coming_Calamity
+Devout Chainmail,1.39%,72,98.61%,,2,The Fourth Vow,,,55.6,https://www.poewiki.net/wiki/The_Fourth_Vow
+Diamond Ring,25.00%,4,50.00%,,4,Gifts from Above,,,1637.3,https://www.poewiki.net/wiki/Gifts_from_Above
+Diamond Ring,25.00%,4,50.00%,,4,Romira's Banquet,,,1637.3,https://www.poewiki.net/wiki/Romira%27s_Banquet
+Dragonscale Boots,40.93%,3,59.07%,,4,Darkray Vectors,,,1637.3,https://www.poewiki.net/wiki/Darkray_Vectors
+Dragonscale Gauntlets,50.00%,2,50.00%,,5,Surgebinders,,,2076.4,https://www.poewiki.net/wiki/Surgebinders
+Dread Maul,40.93%,3,59.07%,,4,Voidhome,,,1637.3,https://www.poewiki.net/wiki/Voidhome
+Dream Mace,50.00%,2,50.00%,,5,Flesh-Eater,,,2076.4,https://www.poewiki.net/wiki/Flesh-Eater
+Driftwood Wand,50.00%,2,50.00%,,5,Lifesprig,,,2076.4,https://www.poewiki.net/wiki/Lifesprig
+Dusk Blade,7.87%,13,92.13%,,3,Ephemeral Edge,,,314.8,https://www.poewiki.net/wiki/Ephemeral_Edge
+Ebony Tower Shield,0.65%,155,50.00%,,1,Tukohama's Fortress,,,27.2,https://www.poewiki.net/wiki/Tukohama%27s_Fortress
+Ebony Tower Shield,49.35%,3,50.00%,,5,Chernobog's Pillar,,,2076.4,https://www.poewiki.net/wiki/Chernobog%27s_Pillar
+Eelskin Boots,50.00%,2,50.00%,,5,Orbala's Stand,,,2076.4,https://www.poewiki.net/wiki/Orbala%27s_Stand
+Eelskin Gloves,40.93%,3,59.07%,,4,Great Old One's Tentacles,,,1637.3,https://www.poewiki.net/wiki/Great_Old_One%27s_Tentacles
+Elder Sword,40.93%,3,59.07%,,4,Innsbury Edge,,,1637.3,https://www.poewiki.net/wiki/Innsbury_Edge
+Elegant Ringmail,40.93%,3,59.07%,,4,Geofri's Sanctuary,,,1637.3,https://www.poewiki.net/wiki/Geofri%27s_Sanctuary
+Elegant Round Shield,0.04%,2771,50.00%,,0,The Squire,,,1.5,https://www.poewiki.net/wiki/The_Squire
+Elegant Round Shield,49.96%,3,50.00%,,5,The Oppressor,,,2076.4,https://www.poewiki.net/wiki/The_Oppressor
+Elegant Sword,50.00%,2,50.00%,,5,Lakishu's Blade,,,2076.4,https://www.poewiki.net/wiki/Lakishu%27s_Blade
+Embroidered Gloves,7.87%,13,92.13%,,3,Vixen's Entrapment,,,314.8,https://www.poewiki.net/wiki/Vixen%27s_Entrapment
+Engraved Greatsword,0.04%,2667,99.96%,,0,Rakiata's Dance,,,1.5,https://www.poewiki.net/wiki/Rakiata%27s_Dance
+Engraved Wand,22.04%,5,50.00%,,4,Midnight Bargain,,,1637.3,https://www.poewiki.net/wiki/Midnight_Bargain
+Engraved Wand,27.96%,4,50.00%,,5,Eclipse Solaris,,,2076.4,https://www.poewiki.net/wiki/Eclipse_Solaris
+Estoc,50.00%,2,50.00%,,5,Daresso's Passion,,,2076.4,https://www.poewiki.net/wiki/Daresso%27s_Passion
+Etched Greatsword,40.93%,3,59.07%,,4,Edge of Madness,,,1637.3,https://www.poewiki.net/wiki/Edge_of_Madness
+Eternal Burgonet,7.87%,13,92.13%,,3,Usurper's Penance,,,314.8,https://www.poewiki.net/wiki/Usurper%27s_Penance
+Eternal Sword,7.87%,13,76.39%,,3,Beltimber Blade,,,314.8,https://www.poewiki.net/wiki/Beltimber_Blade
+Eternal Sword,7.87%,13,76.39%,,3,Grelwood Shank,,,314.8,https://www.poewiki.net/wiki/Grelwood_Shank
+Eternal Sword,7.87%,13,76.39%,,3,Dreamfeather,,,314.8,https://www.poewiki.net/wiki/Dreamfeather
+Exquisite Leather,1.39%,72,97.22%,,2,Yriel's Fostering,,,55.6,https://www.poewiki.net/wiki/Yriel%27s_Fostering
+Exquisite Leather,1.39%,72,97.22%,,2,Kintsugi,,,55.6,https://www.poewiki.net/wiki/Kintsugi
+Ezomyte Axe,25.00%,4,50.00%,,5,Sinvicta's Mettle,,,2076.4,https://www.poewiki.net/wiki/Sinvicta%27s_Mettle
+Ezomyte Axe,25.00%,4,50.00%,,5,Wings of Entropy,,,2076.4,https://www.poewiki.net/wiki/Wings_of_Entropy
+Ezomyte Blade,50.00%,2,50.00%,,5,Kondo's Pride,,,2076.4,https://www.poewiki.net/wiki/Kondo%27s_Pride
+Ezomyte Burgonet,7.87%,13,92.13%,,3,Abyssus,,,314.8,https://www.poewiki.net/wiki/Abyssus
+Ezomyte Dagger,7.87%,13,92.13%,,3,Cold Iron Point,,,314.8,https://www.poewiki.net/wiki/Cold_Iron_Point
+Ezomyte Staff,25.00%,4,50.00%,,4,Cane of Unravelling,,,1637.3,https://www.poewiki.net/wiki/Cane_of_Unravelling
+Ezomyte Staff,25.00%,4,50.00%,,4,Soulwrest,,,1637.3,https://www.poewiki.net/wiki/Soulwrest
+Feathered Arrow Quiver,25.00%,4,50.00%,,5,Saemus' Gift,,,2076.4,https://www.poewiki.net/wiki/Saemus%27_Gift
+Feathered Arrow Quiver,25.00%,4,50.00%,,5,Asphyxia's Wrath,,,2076.4,https://www.poewiki.net/wiki/Asphyxia%27s_Wrath
+Festival Mask,50.00%,2,50.00%,,5,Leer Cast,,,2076.4,https://www.poewiki.net/wiki/Leer_Cast
+Fiend Dagger,0.68%,148,58.39%,,1,Arakaali's Fang,,,27.2,https://www.poewiki.net/wiki/Arakaali%27s_Fang
+Fiend Dagger,40.93%,3,58.39%,,4,The Consuming Dark,,,1637.3,https://www.poewiki.net/wiki/The_Consuming_Dark
+Fishing Rod,0.04%,2667,99.96%,,0,Reefbane,,,1.5,https://www.poewiki.net/wiki/Reefbane
+Flaying Knife,50.00%,2,50.00%,,5,Mightflay,,,2076.4,https://www.poewiki.net/wiki/Mightflay
+Fright Claw,50.00%,2,50.00%,,5,Mortem Morsu,,,2076.4,https://www.poewiki.net/wiki/Mortem_Morsu
+Full Dragonscale,7.87%,13,92.13%,,3,Daresso's Defiance,,,314.8,https://www.poewiki.net/wiki/Daresso%27s_Defiance
+Full Wyrmscale,7.87%,13,92.13%,,3,Belly of the Beast,,,314.8,https://www.poewiki.net/wiki/Belly_of_the_Beast
+Gavel,1.30%,77,50.00%,,2,Mjölner,,,55.6,https://www.poewiki.net/wiki/Mjölner
+Gavel,48.70%,3,50.00%,,5,Cameria's Maul,,,2076.4,https://www.poewiki.net/wiki/Cameria%27s_Maul
+Gilded Sallet,7.87%,13,92.13%,,3,Deidbell,,,314.8,https://www.poewiki.net/wiki/Deidbell
+Gladiator Plate,1.39%,72,98.61%,,2,The Brass Dome,,,55.6,https://www.poewiki.net/wiki/The_Brass_Dome
+Gladius,40.93%,3,59.07%,,4,Scaeva,,,1637.3,https://www.poewiki.net/wiki/Scaeva
+Glorious Plate,1.39%,72,90.74%,,2,Kaom's Heart,,,55.6,https://www.poewiki.net/wiki/Kaom%27s_Heart
+Glorious Plate,7.87%,13,90.74%,,3,Perfidy,,,314.8,https://www.poewiki.net/wiki/Perfidy
+Gnarled Branch,25.00%,4,50.00%,,5,Fencoil,,,2076.4,https://www.poewiki.net/wiki/Fencoil
+Gnarled Branch,25.00%,4,50.00%,,5,The Blood Thorn,,,2076.4,https://www.poewiki.net/wiki/The_Blood_Thorn
+Goat's Horn,50.00%,2,50.00%,,5,Abberath's Horn,,,2076.4,https://www.poewiki.net/wiki/Abberath%27s_Horn
+Goathide Boots,0.68%,148,58.39%,,1,Abberath's Hooves,,,27.2,https://www.poewiki.net/wiki/Abberath%27s_Hooves
+Goathide Boots,40.93%,3,58.39%,,4,Victario's Flight,,,1637.3,https://www.poewiki.net/wiki/Victario%27s_Flight
+Goathide Gloves,50.00%,2,50.00%,,5,Hrimsorrow,,,2076.4,https://www.poewiki.net/wiki/Hrimsorrow
+Gold Amulet,0.43%,233,50.00%,,2,The Untouched Soul,,,55.6,https://www.poewiki.net/wiki/The_Untouched_Soul
+Gold Amulet,2.43%,42,50.00%,,3,Bisco's Collar,,,314.8,https://www.poewiki.net/wiki/Bisco%27s_Collar
+Gold Amulet,2.43%,42,50.00%,,3,The Ascetic,,,314.8,https://www.poewiki.net/wiki/The_Ascetic
+Gold Amulet,12.64%,8,50.00%,,4,Perquil's Toe,,,1637.3,https://www.poewiki.net/wiki/Perquil%27s_Toe
+Gold Amulet,16.03%,7,50.00%,,5,Winterheart,,,2076.4,https://www.poewiki.net/wiki/Winterheart
+Gold Amulet,16.03%,7,50.00%,,5,The Ignomon,,,2076.4,https://www.poewiki.net/wiki/The_Ignomon
+Gold Ring,3.91%,26,50.00%,,3,Andvarius,,,314.8,https://www.poewiki.net/wiki/Andvarius
+Gold Ring,20.32%,5,50.00%,,4,Ventor's Gamble,,,1637.3,https://www.poewiki.net/wiki/Ventor%27s_Gamble
+Gold Ring,25.77%,4,50.00%,,5,The Highwayman,,,2076.4,https://www.poewiki.net/wiki/The_Highwayman
+Golden Mask,25.00%,4,50.00%,,5,Willclash,,,2076.4,https://www.poewiki.net/wiki/Willclash
+Golden Mask,25.00%,4,50.00%,,5,The Three Dragons,,,2076.4,https://www.poewiki.net/wiki/The_Three_Dragons
+Golden Plate,40.93%,3,59.07%,,4,Greed's Embrace,,,1637.3,https://www.poewiki.net/wiki/Greed%27s_Embrace
+Goliath Gauntlets,50.00%,2,50.00%,,5,Empire's Grasp,,,2076.4,https://www.poewiki.net/wiki/Empire%27s_Grasp
+Graceful Sword,40.93%,3,59.07%,,4,Nametaker,,,1637.3,https://www.poewiki.net/wiki/Nametaker
+Great Crown,40.93%,3,59.07%,,4,Geofri's Crest,,,1637.3,https://www.poewiki.net/wiki/Geofri%27s_Crest
+Great Helmet,40.93%,3,59.07%,,4,Veil of the Night,,,1637.3,https://www.poewiki.net/wiki/Veil_of_the_Night
+Great Mallet,6.58%,16,50.00%,,3,Trypanon,,,314.8,https://www.poewiki.net/wiki/Trypanon
+Great Mallet,43.42%,3,50.00%,,5,Chober Chaber,,,2076.4,https://www.poewiki.net/wiki/Chober_Chaber
+Grinning Fetish,50.00%,2,50.00%,,5,Earendel's Embrace,,,2076.4,https://www.poewiki.net/wiki/Earendel%27s_Embrace
+Gut Ripper,25.00%,4,50.00%,,5,Advancing Fortress,,,2076.4,https://www.poewiki.net/wiki/Advancing_Fortress
+Gut Ripper,25.00%,4,50.00%,,5,Ornament of the East,,,2076.4,https://www.poewiki.net/wiki/Ornament_of_the_East
+Harbinger Bow,22.04%,5,50.00%,,4,Slivertongue,,,1637.3,https://www.poewiki.net/wiki/Slivertongue
+Harbinger Bow,27.96%,4,50.00%,,5,Nuro's Harp,,,2076.4,https://www.poewiki.net/wiki/Nuro%27s_Harp
+Harlequin Mask,7.87%,13,92.13%,,3,Mind of the Council,,,314.8,https://www.poewiki.net/wiki/Mind_of_the_Council
+Harmonic Spirit Shield,40.93%,3,59.07%,,4,Malachai's Loop,,,1637.3,https://www.poewiki.net/wiki/Malachai%27s_Loop
+Headsman Axe,50.00%,2,50.00%,,5,The Blood Reaper,,,2076.4,https://www.poewiki.net/wiki/The_Blood_Reaper
+Heavy Arrow Quiver,40.93%,3,59.07%,,4,Scorpion's Call,,,1637.3,https://www.poewiki.net/wiki/Scorpion%27s_Call
+Heavy Belt,0.01%,8816,50.00%,,0,Mageblood,,,1.5,https://www.poewiki.net/wiki/Mageblood
+Heavy Belt,2.38%,43,50.00%,,3,Dyadian Dawn,,,314.8,https://www.poewiki.net/wiki/Dyadian_Dawn
+Heavy Belt,2.38%,43,50.00%,,3,Kaom's Binding,,,314.8,https://www.poewiki.net/wiki/Kaom%27s_Binding
+Heavy Belt,2.38%,43,50.00%,,3,Mother's Embrace,,,314.8,https://www.poewiki.net/wiki/Mother%27s_Embrace
+Heavy Belt,2.38%,43,50.00%,,3,Bisco's Leash,,,314.8,https://www.poewiki.net/wiki/Bisco%27s_Leash
+Heavy Belt,12.38%,9,50.00%,,4,Belt of the Deceiver,,,1637.3,https://www.poewiki.net/wiki/Belt_of_the_Deceiver
+Heavy Belt,12.38%,9,50.00%,,4,Meginord's Girdle,,,1637.3,https://www.poewiki.net/wiki/Meginord%27s_Girdle
+Heavy Belt,15.70%,7,50.00%,,5,Siegebreaker,,,2076.4,https://www.poewiki.net/wiki/Siegebreaker
+Hellion's Paw,0.04%,2667,99.96%,,0,Bloodseeker,,,1.5,https://www.poewiki.net/wiki/Bloodseeker
+Highborn Staff,0.68%,148,99.32%,,1,Martyr of Innocence,,,27.2,https://www.poewiki.net/wiki/Martyr_of_Innocence
+Highland Blade,50.00%,2,50.00%,,5,Rigwald's Charge,,,2076.4,https://www.poewiki.net/wiki/Rigwald%27s_Charge
+Holy Chainmail,7.87%,13,92.13%,,3,Voll's Protector,,,314.8,https://www.poewiki.net/wiki/Voll%27s_Protector
+Hubris Circlet,6.94%,15,50.00%,,3,Ylfeban's Trickery,,,314.8,https://www.poewiki.net/wiki/Ylfeban%27s_Trickery
+Hubris Circlet,6.94%,15,50.00%,,3,Crown of Eyes,,,314.8,https://www.poewiki.net/wiki/Crown_of_Eyes
+Hubris Circlet,36.11%,3,50.00%,,4,Eber's Unification,,,1637.3,https://www.poewiki.net/wiki/Eber%27s_Unification
+Hydrascale Gauntlets,1.39%,72,98.61%,,2,Gravebind,,,55.6,https://www.poewiki.net/wiki/Gravebind
+Imbued Wand,14.14%,8,50.00%,,4,Piscator's Vigil,,,1637.3,https://www.poewiki.net/wiki/Piscator%27s_Vigil
+Imbued Wand,17.93%,6,50.00%,,5,Moonsorrow,,,2076.4,https://www.poewiki.net/wiki/Moonsorrow
+Imbued Wand,17.93%,6,50.00%,,5,Obliteration,,,2076.4,https://www.poewiki.net/wiki/Obliteration
+Imperial Bow,0.04%,2667,98.57%,,0,Lioneye's Glare,,,1.5,https://www.poewiki.net/wiki/Lioneye%27s_Glare
+Imperial Bow,1.39%,72,98.57%,,2,Windripper,,,55.6,https://www.poewiki.net/wiki/Windripper
+Imperial Claw,40.93%,3,59.07%,,4,Touch of Anguish,,,1637.3,https://www.poewiki.net/wiki/Touch_of_Anguish
+Imperial Maul,0.68%,148,99.32%,,1,Tidebreaker,,,27.2,https://www.poewiki.net/wiki/Tidebreaker
+Imperial Skean,0.04%,2771,50.00%,,0,Divinarius,,,1.5,https://www.poewiki.net/wiki/Divinarius
+Imperial Skean,49.96%,3,50.00%,,5,White Wind,,,2076.4,https://www.poewiki.net/wiki/White_Wind
+Imperial Staff,12.50%,8,50.00%,,4,Agnerod South,,,1637.3,https://www.poewiki.net/wiki/Agnerod_South
+Imperial Staff,12.50%,8,50.00%,,4,Agnerod North,,,1637.3,https://www.poewiki.net/wiki/Agnerod_North
+Imperial Staff,12.50%,8,50.00%,,4,Agnerod West,,,1637.3,https://www.poewiki.net/wiki/Agnerod_West
+Imperial Staff,12.50%,8,50.00%,,4,Agnerod East,,,1637.3,https://www.poewiki.net/wiki/Agnerod_East
+Infernal Axe,40.93%,3,59.07%,,4,Dyadus,,,1637.3,https://www.poewiki.net/wiki/Dyadus
+Infernal Sword,50.00%,2,50.00%,,5,Oro's Sacrifice,,,2076.4,https://www.poewiki.net/wiki/Oro%27s_Sacrifice
+Iron Circlet,1.39%,72,57.68%,,2,Asenath's Mark,,,55.6,https://www.poewiki.net/wiki/Asenath%27s_Mark
+Iron Circlet,40.93%,3,57.68%,,4,Wreath of Phrecia,,,1637.3,https://www.poewiki.net/wiki/Wreath_of_Phrecia
+Iron Gauntlets,50.00%,2,50.00%,,5,Lochtonial Caress,,,2076.4,https://www.poewiki.net/wiki/Lochtonial_Caress
+Iron Hat,50.00%,2,50.00%,,5,Ezomyte Peak,,,2076.4,https://www.poewiki.net/wiki/Ezomyte_Peak
+Iron Mask,40.93%,3,59.07%,,4,Malachai's Simula,,,1637.3,https://www.poewiki.net/wiki/Malachai%27s_Simula
+Iron Ring,9.03%,12,50.00%,,4,Le Heup of All,,,1637.3,https://www.poewiki.net/wiki/Le_Heup_of_All
+Iron Ring,9.03%,12,50.00%,,4,Venopuncture,,,1637.3,https://www.poewiki.net/wiki/Venopuncture
+Iron Ring,9.03%,12,50.00%,,4,Icefang Orbit,,,1637.3,https://www.poewiki.net/wiki/Icefang_Orbit
+Iron Ring,11.45%,9,50.00%,,5,The Warden's Brand,,,2076.4,https://www.poewiki.net/wiki/The_Warden%27s_Brand
+Iron Ring,11.45%,9,50.00%,,5,Blackheart,,,2076.4,https://www.poewiki.net/wiki/Blackheart
+Iron Staff,16.67%,6,50.00%,,5,Pillar of the Caged God,,,2076.4,https://www.poewiki.net/wiki/Pillar_of_the_Caged_God
+Iron Staff,16.67%,6,50.00%,,5,Dying Breath,,,2076.4,https://www.poewiki.net/wiki/Dying_Breath
+Iron Staff,16.67%,6,50.00%,,5,Realmshaper,,,2076.4,https://www.poewiki.net/wiki/Realmshaper
+Ironscale Boots,50.00%,2,50.00%,,5,Dusktoe,,,2076.4,https://www.poewiki.net/wiki/Dusktoe
+Ironscale Gauntlets,40.93%,3,59.07%,,4,Flesh and Spirit,,,1637.3,https://www.poewiki.net/wiki/Flesh_and_Spirit
+Ironwood Buckler,40.93%,3,59.07%,,4,Kiloava's Bluster,,,1637.3,https://www.poewiki.net/wiki/Kiloava%27s_Bluster
+Jade Amulet,2.78%,36,50.00%,,3,Rashkaldor's Patience,,,314.8,https://www.poewiki.net/wiki/Rashkaldor%27s_Patience
+Jade Amulet,14.45%,7,50.00%,,4,Hyrri's Truth,,,1637.3,https://www.poewiki.net/wiki/Hyrri%27s_Truth
+Jade Amulet,14.45%,7,50.00%,,4,Willowgift,,,1637.3,https://www.poewiki.net/wiki/Willowgift
+Jade Amulet,18.32%,6,50.00%,,5,Karui Ward,,,2076.4,https://www.poewiki.net/wiki/Karui_Ward
+Jade Hatchet,50.00%,2,50.00%,,5,The Screaming Eagle,,,2076.4,https://www.poewiki.net/wiki/The_Screaming_Eagle
+Jagged Foil,50.00%,2,50.00%,,5,Fidelitas' Spike,,,2076.4,https://www.poewiki.net/wiki/Fidelitas%27_Spike
+Jagged Maul,50.00%,2,50.00%,,5,Quecholli,,,2076.4,https://www.poewiki.net/wiki/Quecholli
+Jasper Chopper,40.93%,3,59.07%,,4,The Harvest,,,1637.3,https://www.poewiki.net/wiki/The_Harvest
+Jewelled Foil,1.39%,72,98.61%,,2,Cospri's Malice,,,55.6,https://www.poewiki.net/wiki/Cospri%27s_Malice
+Jingling Spirit Shield,0.68%,148,99.32%,,1,Light of Lunaris,,,27.2,https://www.poewiki.net/wiki/Light_of_Lunaris
+Judgement Staff,7.87%,13,84.26%,,3,The Grey Spire,,,314.8,https://www.poewiki.net/wiki/The_Grey_Spire
+Judgement Staff,7.87%,13,84.26%,,3,Hegemony's Era,,,314.8,https://www.poewiki.net/wiki/Hegemony%27s_Era
+Karui Chopper,40.93%,3,59.07%,,4,Kaom's Primacy,,,1637.3,https://www.poewiki.net/wiki/Kaom%27s_Primacy
+Karui Maul,0.04%,2667,99.96%,,0,Marohi Erqi,,,1.5,https://www.poewiki.net/wiki/Marohi_Erqi
+Karui Sceptre,1.30%,77,50.00%,,2,Maata's Teaching,,,55.6,https://www.poewiki.net/wiki/Maata%27s_Teaching
+Karui Sceptre,48.70%,3,50.00%,,5,Death's Hand,,,2076.4,https://www.poewiki.net/wiki/Death%27s_Hand
+Lacquered Buckler,7.87%,13,92.13%,,3,Mistwall,,,314.8,https://www.poewiki.net/wiki/Mistwall
+Lacquered Garb,1.39%,72,57.68%,,2,Cloak of Defiance,,,55.6,https://www.poewiki.net/wiki/Cloak_of_Defiance
+Lacquered Garb,40.93%,3,57.68%,,4,Victario's Influence,,,1637.3,https://www.poewiki.net/wiki/Victario%27s_Influence
+Lacquered Helmet,50.00%,2,50.00%,,5,Black Sun Crest,,,2076.4,https://www.poewiki.net/wiki/Black_Sun_Crest
+Laminated Kite Shield,50.00%,2,50.00%,,5,Victario's Charity,,,2076.4,https://www.poewiki.net/wiki/Victario%27s_Charity
+Lapis Amulet,2.30%,44,50.00%,,3,Marylene's Fallacy,,,314.8,https://www.poewiki.net/wiki/Marylene%27s_Fallacy
+Lapis Amulet,2.30%,44,50.00%,,3,Doedre's Tongue,,,314.8,https://www.poewiki.net/wiki/Doedre%27s_Tongue
+Lapis Amulet,15.14%,7,50.00%,,5,The Ephemeral Bond,,,2076.4,https://www.poewiki.net/wiki/The_Ephemeral_Bond
+Lapis Amulet,15.14%,7,50.00%,,5,Tear of Purity,,,2076.4,https://www.poewiki.net/wiki/Tear_of_Purity
+Lapis Amulet,15.14%,7,50.00%,,5,Stone of Lazhwar,,,2076.4,https://www.poewiki.net/wiki/Stone_of_Lazhwar
+Lathi,7.87%,13,92.13%,,3,The Searing Touch,,,314.8,https://www.poewiki.net/wiki/The_Searing_Touch
+Latticed Ringmail,50.00%,2,50.00%,,5,Icetomb,,,2076.4,https://www.poewiki.net/wiki/Icetomb
+Leather Belt,0.01%,10745,50.00%,,0,Headhunter,,,1.5,https://www.poewiki.net/wiki/Headhunter
+Leather Belt,1.95%,52,50.00%,,3,Leash of Oblation,,,314.8,https://www.poewiki.net/wiki/Leash_of_Oblation
+Leather Belt,1.95%,52,50.00%,,3,Umbilicus Immortalis,,,314.8,https://www.poewiki.net/wiki/Umbilicus_Immortalis
+Leather Belt,10.16%,10,50.00%,,4,Gluttony,,,1637.3,https://www.poewiki.net/wiki/Gluttony
+Leather Belt,10.16%,10,50.00%,,4,Pyroshock Clasp,,,1637.3,https://www.poewiki.net/wiki/Pyroshock_Clasp
+Leather Belt,12.88%,8,50.00%,,5,Wurm's Molt,,,2076.4,https://www.poewiki.net/wiki/Wurm%27s_Molt
+Leather Belt,12.88%,8,50.00%,,5,Immortal Flesh,,,2076.4,https://www.poewiki.net/wiki/Immortal_Flesh
+Leather Cap,40.93%,3,59.07%,,4,Goldrim,,,1637.3,https://www.poewiki.net/wiki/Goldrim
+Leather Hood,7.87%,13,92.13%,,3,Heatshiver,,,314.8,https://www.poewiki.net/wiki/Heatshiver
+Legion Boots,25.00%,4,50.00%,,5,Gang's Momentum,,,2076.4,https://www.poewiki.net/wiki/Gang%27s_Momentum
+Legion Boots,25.00%,4,50.00%,,5,March of the Legion,,,2076.4,https://www.poewiki.net/wiki/March_of_the_Legion
+Legion Gloves,40.93%,3,59.07%,,4,Null and Void,,,1637.3,https://www.poewiki.net/wiki/Null_and_Void
+Legion Sword,40.93%,3,59.07%,,4,Hyaon's Fury,,,1637.3,https://www.poewiki.net/wiki/Hyaon%27s_Fury
+Lion Pelt,40.93%,3,59.07%,,4,Obscurantis,,,1637.3,https://www.poewiki.net/wiki/Obscurantis
+Lion Sword,7.87%,13,92.13%,,3,Doomsower,,,314.8,https://www.poewiki.net/wiki/Doomsower
+Long Bow,50.00%,2,50.00%,,5,Storm Cloud,,,2076.4,https://www.poewiki.net/wiki/Storm_Cloud
+Lunaris Circlet,40.93%,3,59.07%,,4,Doedre's Scorn,,,1637.3,https://www.poewiki.net/wiki/Doedre%27s_Scorn
+Maelström Staff,7.87%,13,92.13%,,3,Taryn's Shiver,,,314.8,https://www.poewiki.net/wiki/Taryn%27s_Shiver
+Majestic Plate,1.39%,72,98.61%,,2,Utula's Hunger,,,55.6,https://www.poewiki.net/wiki/Utula%27s_Hunger
+Maple Round Shield,40.93%,3,59.07%,,4,The Flawed Refuge,,,1637.3,https://www.poewiki.net/wiki/The_Flawed_Refuge
+Marble Amulet,50.00%,2,50.00%,,5,Bloodgrip,,,2076.4,https://www.poewiki.net/wiki/Bloodgrip
+Meatgrinder,7.87%,13,92.13%,,3,Brain Rattler,,,314.8,https://www.poewiki.net/wiki/Brain_Rattler
+Mesh Boots,50.00%,2,50.00%,,5,Wake of Destruction,,,2076.4,https://www.poewiki.net/wiki/Wake_of_Destruction
+Mesh Gloves,50.00%,2,50.00%,,5,Triad Grip,,,2076.4,https://www.poewiki.net/wiki/Triad_Grip
+Midnight Blade,4.39%,23,50.00%,,3,Razor of the Seventh Sun,,,314.8,https://www.poewiki.net/wiki/Razor_of_the_Seventh_Sun
+Midnight Blade,22.81%,5,50.00%,,4,Ahn's Might,,,1637.3,https://www.poewiki.net/wiki/Ahn%27s_Might
+Midnight Blade,22.81%,5,50.00%,,4,Rigwald's Command,,,1637.3,https://www.poewiki.net/wiki/Rigwald%27s_Command
+Military Staff,7.87%,13,92.13%,,3,Tremor Rod,,,314.8,https://www.poewiki.net/wiki/Tremor_Rod
+Mind Cage,7.87%,13,84.26%,,3,Rime Gaze,,,314.8,https://www.poewiki.net/wiki/Rime_Gaze
+Mind Cage,7.87%,13,84.26%,,3,Scold's Bridle,,,314.8,https://www.poewiki.net/wiki/Scold%27s_Bridle
+Mirrored Spiked Shield,50.00%,2,50.00%,,5,Leper's Alms,,,2076.4,https://www.poewiki.net/wiki/Leper%27s_Alms
+Moonstone Ring,0.37%,272,50.00%,,2,Anathema,,,55.6,https://www.poewiki.net/wiki/Anathema
+Moonstone Ring,0.37%,272,50.00%,,2,Shavronne's Revelation,,,55.6,https://www.poewiki.net/wiki/Shavronne%27s_Revelation
+Moonstone Ring,10.86%,10,50.00%,,4,Timeclasp,,,1637.3,https://www.poewiki.net/wiki/Timeclasp
+Moonstone Ring,10.86%,10,50.00%,,4,Heartbound Loop,,,1637.3,https://www.poewiki.net/wiki/Heartbound_Loop
+Moonstone Ring,13.77%,8,50.00%,,5,Valyrium,,,2076.4,https://www.poewiki.net/wiki/Valyrium
+Moonstone Ring,13.77%,8,50.00%,,5,Tawhanuku's Timing,,,2076.4,https://www.poewiki.net/wiki/Tawhanuku%27s_Timing
+Mosaic Kite Shield,40.93%,3,59.07%,,4,Rise of the Phoenix,,,1637.3,https://www.poewiki.net/wiki/Rise_of_the_Phoenix
+Murder Mitts,1.39%,72,97.22%,,2,Thunderfist,,,55.6,https://www.poewiki.net/wiki/Thunderfist
+Murder Mitts,1.39%,72,97.22%,,2,Machina Mitts,,,55.6,https://www.poewiki.net/wiki/Machina_Mitts
+Nailed Fist,50.00%,2,50.00%,,5,Last Resort,,,2076.4,https://www.poewiki.net/wiki/Last_Resort
+Necromancer Circlet,7.87%,13,92.13%,,3,Chitus' Apex,,,314.8,https://www.poewiki.net/wiki/Chitus%27_Apex
+Necromancer Silks,1.39%,72,57.68%,,2,Fleshcrafter,,,55.6,https://www.poewiki.net/wiki/Fleshcrafter
+Necromancer Silks,40.93%,3,57.68%,,4,Vis Mortis,,,1637.3,https://www.poewiki.net/wiki/Vis_Mortis
+Nightmare Bascinet,6.58%,16,50.00%,,3,The Bringer of Rain,,,314.8,https://www.poewiki.net/wiki/The_Bringer_of_Rain
+Nightmare Bascinet,43.42%,3,50.00%,,5,Devoto's Devotion,,,2076.4,https://www.poewiki.net/wiki/Devoto%27s_Devotion
+Nubuck Boots,40.93%,3,59.07%,,4,Goldwyrm,,,1637.3,https://www.poewiki.net/wiki/Goldwyrm
+Nubuck Gloves,40.93%,3,59.07%,,4,Oskarm,,,1637.3,https://www.poewiki.net/wiki/Oskarm
+Occultist's Vestment,1.39%,72,98.61%,,2,Shavronne's Wrappings,,,55.6,https://www.poewiki.net/wiki/Shavronne%27s_Wrappings
+Omen Wand,7.87%,13,92.13%,,3,Apep's Rage,,,314.8,https://www.poewiki.net/wiki/Apep%27s_Rage
+Onyx Amulet,0.90%,111,50.00%,,2,Astramentis,,,55.6,https://www.poewiki.net/wiki/Astramentis
+Onyx Amulet,5.12%,20,50.00%,,3,Hinekora's Sight,,,314.8,https://www.poewiki.net/wiki/Hinekora%27s_Sight
+Onyx Amulet,5.12%,20,50.00%,,3,Replica Dragonfang's Flight,,,314.8,https://www.poewiki.net/wiki/Replica_Dragonfang%27s_Flight
+Onyx Amulet,5.12%,20,50.00%,,3,Eye of Chayula,,,314.8,https://www.poewiki.net/wiki/Eye_of_Chayula
+Onyx Amulet,33.75%,3,50.00%,,5,Carnage Heart,,,2076.4,https://www.poewiki.net/wiki/Carnage_Heart
+Opal Ring,40.93%,3,59.07%,,4,Stormfire,,,1637.3,https://www.poewiki.net/wiki/Stormfire
+Opal Sceptre,50.00%,2,50.00%,,5,Balefire,,,2076.4,https://www.poewiki.net/wiki/Balefire
+Ornate Mace,40.93%,3,59.07%,,4,Frostbreath,,,1637.3,https://www.poewiki.net/wiki/Frostbreath
+Ornate Ringmail,50.00%,2,50.00%,,5,Lightbane Raiment,,,2076.4,https://www.poewiki.net/wiki/Lightbane_Raiment
+Ornate Sword,50.00%,2,50.00%,,5,Queen's Decree,,,2076.4,https://www.poewiki.net/wiki/Queen%27s_Decree
+Painted Buckler,50.00%,2,50.00%,,5,Kaltenhalt,,,2076.4,https://www.poewiki.net/wiki/Kaltenhalt
+Paua Amulet,0.04%,2845,50.00%,,0,Defiance of Destiny,,,1.5,https://www.poewiki.net/wiki/Defiance_of_Destiny
+Paua Amulet,1.30%,77,50.00%,,2,Atziri's Foible,,,55.6,https://www.poewiki.net/wiki/Atziri%27s_Foible
+Paua Amulet,48.66%,3,50.00%,,5,Sidhebreath,,,2076.4,https://www.poewiki.net/wiki/Sidhebreath
+Paua Ring,2.78%,36,50.00%,,3,Perandus Signet,,,314.8,https://www.poewiki.net/wiki/Perandus_Signet
+Paua Ring,14.45%,7,50.00%,,4,Soulbound,,,1637.3,https://www.poewiki.net/wiki/Soulbound
+Paua Ring,14.45%,7,50.00%,,4,Doedre's Damning,,,1637.3,https://www.poewiki.net/wiki/Doedre%27s_Damning
+Paua Ring,18.32%,6,50.00%,,5,Praxis,,,2076.4,https://www.poewiki.net/wiki/Praxis
+Penetrating Arrow Quiver,40.93%,3,59.07%,,4,Drillneck,,,1637.3,https://www.poewiki.net/wiki/Drillneck
+Pine Buckler,50.00%,2,50.00%,,5,Crest of Perandus,,,2076.4,https://www.poewiki.net/wiki/Crest_of_Perandus
+Pinnacle Tower Shield,7.87%,13,92.13%,,3,Lioneye's Remorse,,,314.8,https://www.poewiki.net/wiki/Lioneye%27s_Remorse
+Plague Mask,40.93%,3,59.07%,,4,Curtain Call,,,1637.3,https://www.poewiki.net/wiki/Curtain_Call
+Plank Kite Shield,50.00%,2,50.00%,,5,Springleaf,,,2076.4,https://www.poewiki.net/wiki/Springleaf
+Plate Vest,40.93%,3,59.07%,,4,Bramblejack,,,1637.3,https://www.poewiki.net/wiki/Bramblejack
+Plated Greaves,50.00%,2,50.00%,,5,Stormcharger,,,2076.4,https://www.poewiki.net/wiki/Stormcharger
+Platinum Kris,50.00%,2,50.00%,,5,Mark of the Doubting Knight,,,2076.4,https://www.poewiki.net/wiki/Mark_of_the_Doubting_Knight
+Platinum Sceptre,40.93%,3,59.07%,,4,Singularity,,,1637.3,https://www.poewiki.net/wiki/Singularity
+Poleaxe,50.00%,2,50.00%,,5,Wideswing,,,2076.4,https://www.poewiki.net/wiki/Wideswing
+Polished Spiked Shield,50.00%,2,50.00%,,5,Zeel's Amplifier,,,2076.4,https://www.poewiki.net/wiki/Zeel%27s_Amplifier
+Praetor Crown,6.94%,15,50.00%,,3,Voll's Vision,,,314.8,https://www.poewiki.net/wiki/Voll%27s_Vision
+Praetor Crown,6.94%,15,50.00%,,3,Memory Vault,,,314.8,https://www.poewiki.net/wiki/Memory_Vault
+Praetor Crown,36.11%,3,50.00%,,4,Ahn's Contempt,,,1637.3,https://www.poewiki.net/wiki/Ahn%27s_Contempt
+Primal Arrow Quiver,40.93%,3,59.07%,,4,The Poised Prism,,,1637.3,https://www.poewiki.net/wiki/The_Poised_Prism
+Primordial Staff,0.04%,2771,50.00%,,0,The Burden of Shadows,,,1.5,https://www.poewiki.net/wiki/The_Burden_of_Shadows
+Primordial Staff,49.96%,3,50.00%,,5,Femurs of the Saints,,,2076.4,https://www.poewiki.net/wiki/Femurs_of_the_Saints
+Prismatic Ring,25.00%,4,50.00%,,4,Lori's Lantern,,,1637.3,https://www.poewiki.net/wiki/Lori%27s_Lantern
+Prismatic Ring,25.00%,4,50.00%,,4,Thief's Torment,,,1637.3,https://www.poewiki.net/wiki/Thief%27s_Torment
+Prophecy Wand,1.39%,72,98.61%,,2,Void Battery,,,55.6,https://www.poewiki.net/wiki/Void_Battery
+Prophet Crown,0.36%,276,50.00%,,1,The Brine Crown,,,27.2,https://www.poewiki.net/wiki/The_Brine_Crown
+Prophet Crown,21.88%,5,50.00%,,4,Speaker's Wreath,,,1637.3,https://www.poewiki.net/wiki/Speaker%27s_Wreath
+Prophet Crown,27.75%,4,50.00%,,5,The Broken Crown,,,2076.4,https://www.poewiki.net/wiki/The_Broken_Crown
+Ranger Bow,7.87%,13,92.13%,,3,Null's Inclination,,,314.8,https://www.poewiki.net/wiki/Null%27s_Inclination
+Raven Mask,1.39%,72,98.61%,,2,The Gull,,,55.6,https://www.poewiki.net/wiki/The_Gull
+Rawhide Boots,1.39%,72,98.61%,,2,Seven-League Step,,,55.6,https://www.poewiki.net/wiki/Seven-League_Step
+Rawhide Tower Shield,7.87%,13,92.13%,,3,Lycosidae,,,314.8,https://www.poewiki.net/wiki/Lycosidae
+Reaver Helmet,7.87%,13,92.13%,,3,Blood Price,,,314.8,https://www.poewiki.net/wiki/Blood_Price
+Reaver Sword,25.00%,4,50.00%,,4,Hiltless,,,1637.3,https://www.poewiki.net/wiki/Hiltless
+Reaver Sword,25.00%,4,50.00%,,4,The Dancing Dervish,,,1637.3,https://www.poewiki.net/wiki/The_Dancing_Dervish
+Recurve Bow,50.00%,2,50.00%,,5,Roth's Reach,,,2076.4,https://www.poewiki.net/wiki/Roth%27s_Reach
+Regicide Mask,7.87%,13,51.20%,,3,Akoya's Gaze,,,314.8,https://www.poewiki.net/wiki/Akoya%27s_Gaze
+Regicide Mask,40.93%,3,51.20%,,4,Crown of the Pale King,,,1637.3,https://www.poewiki.net/wiki/Crown_of_the_Pale_King
+Reinforced Greaves,7.87%,13,92.13%,,3,Windscream,,,314.8,https://www.poewiki.net/wiki/Windscream
+Reinforced Tower Shield,50.00%,2,50.00%,,5,Titucius' Span,,,2076.4,https://www.poewiki.net/wiki/Titucius%27_Span
+Ritual Sceptre,7.87%,13,92.13%,,3,Brutus' Lead Sprinkler,,,314.8,https://www.poewiki.net/wiki/Brutus%27_Lead_Sprinkler
+Riveted Boots,0.68%,148,99.32%,,1,Ralakesh's Impatience,,,27.2,https://www.poewiki.net/wiki/Ralakesh%27s_Impatience
+Rock Breaker,50.00%,2,50.00%,,5,Clayshaper,,,2076.4,https://www.poewiki.net/wiki/Clayshaper
+Rotted Round Shield,50.00%,2,50.00%,,5,Wheel of the Stormsail,,,2076.4,https://www.poewiki.net/wiki/Wheel_of_the_Stormsail
+Royal Axe,40.93%,3,59.07%,,4,Rigwald's Savagery,,,1637.3,https://www.poewiki.net/wiki/Rigwald%27s_Savagery
+Royal Bow,7.87%,13,92.13%,,3,Doomfletch,,,314.8,https://www.poewiki.net/wiki/Doomfletch
+Royal Sceptre,40.93%,3,59.07%,,4,The Black Cane,,,1637.3,https://www.poewiki.net/wiki/The_Black_Cane
+Royal Skean,50.00%,2,50.00%,,5,Heartbreaker,,,2076.4,https://www.poewiki.net/wiki/Heartbreaker
+Royal Staff,50.00%,2,50.00%,,5,The Stormheart,,,2076.4,https://www.poewiki.net/wiki/The_Stormheart
+Ruby Ring,0.76%,132,50.00%,,2,Warrior's Legacy,,,55.6,https://www.poewiki.net/wiki/Warrior%27s_Legacy
+Ruby Ring,4.32%,24,50.00%,,3,Emberwake,,,314.8,https://www.poewiki.net/wiki/Emberwake
+Ruby Ring,22.46%,5,50.00%,,4,Ngamahu's Sign,,,1637.3,https://www.poewiki.net/wiki/Ngamahu%27s_Sign
+Ruby Ring,22.46%,5,50.00%,,4,Mokou's Embrace,,,1637.3,https://www.poewiki.net/wiki/Mokou%27s_Embrace
+Rusted Sword,50.00%,2,50.00%,,5,Redbeak,,,2076.4,https://www.poewiki.net/wiki/Redbeak
+Rustic Sash,16.67%,6,50.00%,,5,Faminebind,,,2076.4,https://www.poewiki.net/wiki/Faminebind
+Rustic Sash,16.67%,6,50.00%,,5,Prismweave,,,2076.4,https://www.poewiki.net/wiki/Prismweave
+Rustic Sash,16.67%,6,50.00%,,5,Feastbind,,,2076.4,https://www.poewiki.net/wiki/Feastbind
+Sabre,50.00%,2,50.00%,,5,The Princess,,,2076.4,https://www.poewiki.net/wiki/The_Princess
+Sadist Garb,1.39%,72,90.74%,,2,Inpulsa's Broken Heart,,,55.6,https://www.poewiki.net/wiki/Inpulsa%27s_Broken_Heart
+Sadist Garb,7.87%,13,90.74%,,3,Tinkerskin,,,314.8,https://www.poewiki.net/wiki/Tinkerskin
+Sage Wand,0.65%,155,50.00%,,1,Shade of Solaris,,,27.2,https://www.poewiki.net/wiki/Shade_of_Solaris
+Sage Wand,49.35%,3,50.00%,,5,Twyzel,,,2076.4,https://www.poewiki.net/wiki/Twyzel
+Sage's Robe,0.65%,155,50.00%,,1,Dialla's Malefaction,,,27.2,https://www.poewiki.net/wiki/Dialla%27s_Malefaction
+Sage's Robe,49.35%,3,50.00%,,5,Zahndethus' Cassock,,,2076.4,https://www.poewiki.net/wiki/Zahndethus%27_Cassock
+Saint's Hauberk,1.39%,72,90.74%,,2,Doryani's Prototype,,,55.6,https://www.poewiki.net/wiki/Doryani%27s_Prototype
+Saint's Hauberk,7.87%,13,90.74%,,3,The Ivory Tower,,,314.8,https://www.poewiki.net/wiki/The_Ivory_Tower
+Saintly Chainmail,7.87%,13,84.26%,,3,Chains of Command,,,314.8,https://www.poewiki.net/wiki/Chains_of_Command
+Saintly Chainmail,7.87%,13,84.26%,,3,Incandescent Heart,,,314.8,https://www.poewiki.net/wiki/Incandescent_Heart
+Samite Gloves,50.00%,2,50.00%,,5,Kalisa's Grace,,,2076.4,https://www.poewiki.net/wiki/Kalisa%27s_Grace
+Samnite Helmet,50.00%,2,50.00%,,5,Hrimnor's Resolve,,,2076.4,https://www.poewiki.net/wiki/Hrimnor%27s_Resolve
+Sapphire Ring,6.10%,17,50.00%,,3,Snakepit,,,314.8,https://www.poewiki.net/wiki/Snakepit
+Sapphire Ring,6.10%,17,50.00%,,3,Pyre,,,314.8,https://www.poewiki.net/wiki/Pyre
+Sapphire Ring,6.10%,17,50.00%,,3,Dream Fragments,,,314.8,https://www.poewiki.net/wiki/Dream_Fragments
+Sapphire Ring,31.71%,4,50.00%,,4,Tasalio's Sign,,,1637.3,https://www.poewiki.net/wiki/Tasalio%27s_Sign
+Satin Gloves,7.87%,13,51.20%,,3,Allelopathy,,,314.8,https://www.poewiki.net/wiki/Allelopathy
+Satin Gloves,40.93%,3,51.20%,,4,Demon Stitcher,,,1637.3,https://www.poewiki.net/wiki/Demon_Stitcher
+Scholar Boots,50.00%,2,50.00%,,5,Shavronne's Pace,,,2076.4,https://www.poewiki.net/wiki/Shavronne%27s_Pace
+Scholar's Robe,7.87%,13,92.13%,,3,Cloak of Flame,,,314.8,https://www.poewiki.net/wiki/Cloak_of_Flame
+Secutor Helm,50.00%,2,50.00%,,5,Skullhead,,,2076.4,https://www.poewiki.net/wiki/Skullhead
+Sentinel Jacket,40.93%,3,59.07%,,4,Dendrobate,,,1637.3,https://www.poewiki.net/wiki/Dendrobate
+Serpentine Staff,40.93%,3,59.07%,,4,Sire of Shards,,,1637.3,https://www.poewiki.net/wiki/Sire_of_Shards
+Serpentscale Gauntlets,7.87%,13,92.13%,,3,Haemophilia,,,314.8,https://www.poewiki.net/wiki/Haemophilia
+Serrated Arrow Quiver,50.00%,2,50.00%,,5,Craghead,,,2076.4,https://www.poewiki.net/wiki/Craghead
+Shadow Axe,50.00%,2,50.00%,,5,Reaper's Pursuit,,,2076.4,https://www.poewiki.net/wiki/Reaper%27s_Pursuit
+Shadow Sceptre,7.87%,13,92.13%,,3,Bitterdream,,,314.8,https://www.poewiki.net/wiki/Bitterdream
+Shagreen Boots,50.00%,2,50.00%,,5,Three-step Assault,,,2076.4,https://www.poewiki.net/wiki/Three-step_Assault
+Shagreen Gloves,50.00%,2,50.00%,,5,Painseeker,,,2076.4,https://www.poewiki.net/wiki/Painseeker
+Sharkskin Boots,7.87%,13,92.13%,,3,The Blood Dance,,,314.8,https://www.poewiki.net/wiki/The_Blood_Dance
+Sharkskin Tunic,7.87%,13,92.13%,,3,The Rat Cage,,,314.8,https://www.poewiki.net/wiki/The_Rat_Cage
+Sharktooth Arrow Quiver,40.93%,3,59.07%,,4,Ahuana's Bite,,,1637.3,https://www.poewiki.net/wiki/Ahuana%27s_Bite
+Short Bow,40.93%,3,59.07%,,4,Quill Rain,,,1637.3,https://www.poewiki.net/wiki/Quill_Rain
+Siege Axe,0.04%,2667,99.96%,,0,Soul Taker,,,1.5,https://www.poewiki.net/wiki/Soul_Taker
+Silk Gloves,7.87%,13,92.13%,,3,Asenath's Gentle Touch,,,314.8,https://www.poewiki.net/wiki/Asenath%27s_Gentle_Touch
+Silk Slippers,50.00%,2,50.00%,,5,Bones of Ullr,,,2076.4,https://www.poewiki.net/wiki/Bones_of_Ullr
+Silken Hood,40.93%,3,59.07%,,4,Starkonja's Head,,,1637.3,https://www.poewiki.net/wiki/Starkonja%27s_Head
+Silken Vest,40.93%,3,59.07%,,4,Ghostwrithe,,,1637.3,https://www.poewiki.net/wiki/Ghostwrithe
+Simple Robe,7.87%,13,84.26%,,3,Tabula Rasa,,,314.8,https://www.poewiki.net/wiki/Tabula_Rasa
+Simple Robe,7.87%,13,84.26%,,3,Thousand Ribbons,,,314.8,https://www.poewiki.net/wiki/Thousand_Ribbons
+Sinner Tricorne,7.87%,13,84.26%,,3,Alpha's Howl,,,314.8,https://www.poewiki.net/wiki/Alpha%27s_Howl
+Sinner Tricorne,7.87%,13,84.26%,,3,Assailum,,,314.8,https://www.poewiki.net/wiki/Assailum
+Skinning Knife,50.00%,2,50.00%,,5,Goredrill,,,2076.4,https://www.poewiki.net/wiki/Goredrill
+Slaughter Knife,0.04%,2667,99.96%,,0,Bino's Kitchen Knife,,,1.5,https://www.poewiki.net/wiki/Bino%27s_Kitchen_Knife
+Sledgehammer,50.00%,2,50.00%,,5,Hrimnor's Hymn,,,2076.4,https://www.poewiki.net/wiki/Hrimnor%27s_Hymn
+Slink Gloves,50.00%,2,50.00%,,5,Mercenary's Lot,,,2076.4,https://www.poewiki.net/wiki/Mercenary%27s_Lot
+Solaris Circlet,1.39%,72,87.96%,,2,Flamesight,,,55.6,https://www.poewiki.net/wiki/Flamesight
+Solaris Circlet,1.39%,72,87.96%,,2,Galesight,,,55.6,https://www.poewiki.net/wiki/Galesight
+Solaris Circlet,1.39%,72,87.96%,,2,Thundersight,,,55.6,https://www.poewiki.net/wiki/Thundersight
+Solaris Circlet,7.87%,13,87.96%,,3,Wilma's Requital,,,314.8,https://www.poewiki.net/wiki/Wilma%27s_Requital
+Soldier Boots,40.93%,3,59.07%,,4,Alberon's Warpath,,,1637.3,https://www.poewiki.net/wiki/Alberon%27s_Warpath
+Soldier Gloves,50.00%,2,50.00%,,5,Southbound,,,2076.4,https://www.poewiki.net/wiki/Southbound
+Soldier Helmet,50.00%,2,50.00%,,5,Honourhome,,,2076.4,https://www.poewiki.net/wiki/Honourhome
+Sorcerer Boots,1.39%,72,98.61%,,2,Skyforth,,,55.6,https://www.poewiki.net/wiki/Skyforth
+Spidersilk Robe,1.39%,72,57.68%,,2,The Covenant,,,55.6,https://www.poewiki.net/wiki/The_Covenant
+Spidersilk Robe,40.93%,3,57.68%,,4,Soul Mantle,,,1637.3,https://www.poewiki.net/wiki/Soul_Mantle
+Spike-Point Arrow Quiver,40.93%,3,59.07%,,4,Soul Strike,,,1637.3,https://www.poewiki.net/wiki/Soul_Strike
+Spiked Club,50.00%,2,50.00%,,5,Gorebreaker,,,2076.4,https://www.poewiki.net/wiki/Gorebreaker
+Spine Bow,0.04%,2667,92.09%,,0,Voltaxic Rift,,,1.5,https://www.poewiki.net/wiki/Voltaxic_Rift
+Spine Bow,7.87%,13,92.09%,,3,Reach of the Council,,,314.8,https://www.poewiki.net/wiki/Reach_of_the_Council
+Spiraled Wand,6.58%,16,50.00%,,3,Reverberation Rod,,,314.8,https://www.poewiki.net/wiki/Reverberation_Rod
+Spiraled Wand,43.42%,3,50.00%,,5,Storm Prison,,,2076.4,https://www.poewiki.net/wiki/Storm_Prison
+Stealth Boots,0.65%,155,50.00%,,1,Garukhan's Flight,,,27.2,https://www.poewiki.net/wiki/Garukhan%27s_Flight
+Stealth Boots,49.35%,3,50.00%,,5,Sin Trek,,,2076.4,https://www.poewiki.net/wiki/Sin_Trek
+Steel Circlet,7.87%,13,92.13%,,3,Maw of Conquest,,,314.8,https://www.poewiki.net/wiki/Maw_of_Conquest
+Steel Gauntlets,7.87%,13,92.13%,,3,Meginord's Vise,,,314.8,https://www.poewiki.net/wiki/Meginord%27s_Vise
+Steel Kite Shield,1.39%,72,98.61%,,2,Emperor's Vigilance,,,55.6,https://www.poewiki.net/wiki/Emperor%27s_Vigilance
+Steelhead,40.93%,3,59.07%,,4,Jorrhast's Blacksteel,,,1637.3,https://www.poewiki.net/wiki/Jorrhast%27s_Blacksteel
+Steelscale Gauntlets,7.87%,13,92.13%,,3,Aurseize,,,314.8,https://www.poewiki.net/wiki/Aurseize
+Stiletto,50.00%,2,50.00%,,5,Bloodplay,,,2076.4,https://www.poewiki.net/wiki/Bloodplay
+Strapped Boots,50.00%,2,50.00%,,5,Nomic's Storm,,,2076.4,https://www.poewiki.net/wiki/Nomic%27s_Storm
+Strapped Mitts,40.93%,3,59.07%,,4,Facebreaker,,,1637.3,https://www.poewiki.net/wiki/Facebreaker
+Studded Belt,0.68%,148,97.93%,,1,Ryslatha's Coil,,,27.2,https://www.poewiki.net/wiki/Ryslatha%27s_Coil
+Studded Belt,1.39%,72,97.93%,,2,The Magnate,,,55.6,https://www.poewiki.net/wiki/The_Magnate
+Studded Round Shield,50.00%,2,50.00%,,5,The Deep One's Hide,,,2076.4,https://www.poewiki.net/wiki/The_Deep_One%27s_Hide
+Sun Leather,50.00%,2,50.00%,,5,Briskwrap,,,2076.4,https://www.poewiki.net/wiki/Briskwrap
+Supreme Spiked Shield,50.00%,2,50.00%,,5,Jaws of Agony,,,2076.4,https://www.poewiki.net/wiki/Jaws_of_Agony
+Tarnished Spirit Shield,40.93%,3,59.07%,,4,Matua Tupuna,,,1637.3,https://www.poewiki.net/wiki/Matua_Tupuna
+Teak Round Shield,40.93%,3,59.07%,,4,The Ghastly Theatre,,,1637.3,https://www.poewiki.net/wiki/The_Ghastly_Theatre
+Terror Claw,6.58%,16,50.00%,,3,The Scourge,,,314.8,https://www.poewiki.net/wiki/The_Scourge
+Terror Claw,43.42%,3,50.00%,,5,Rive,,,2076.4,https://www.poewiki.net/wiki/Rive
+Terror Maul,40.93%,3,59.07%,,4,Kongor's Undying Rage,,,1637.3,https://www.poewiki.net/wiki/Kongor%27s_Undying_Rage
+Thresher Claw,50.00%,2,50.00%,,5,Cybil's Paw,,,2076.4,https://www.poewiki.net/wiki/Cybil%27s_Paw
+Throat Stabber,50.00%,2,50.00%,,5,The Wasp Nest,,,2076.4,https://www.poewiki.net/wiki/The_Wasp_Nest
+Tiger Sword,50.00%,2,50.00%,,5,Terminus Est,,,2076.4,https://www.poewiki.net/wiki/Terminus_Est
+Timeworn Claw,40.93%,3,59.07%,,4,Al Dhih,,,1637.3,https://www.poewiki.net/wiki/Al_Dhih
+Titan Gauntlets,6.58%,16,50.00%,,3,Kaom's Spirit,,,314.8,https://www.poewiki.net/wiki/Kaom%27s_Spirit
+Titan Gauntlets,43.42%,3,50.00%,,5,Veruso's Battering Rams,,,2076.4,https://www.poewiki.net/wiki/Veruso%27s_Battering_Rams
+Titan Greaves,7.87%,13,92.13%,,3,Kaom's Roots,,,314.8,https://www.poewiki.net/wiki/Kaom%27s_Roots
+Titanium Spirit Shield,1.39%,72,98.61%,,2,Rathpith Globe,,,55.6,https://www.poewiki.net/wiki/Rathpith_Globe
+Tomahawk,40.93%,3,59.07%,,4,Moonbender's Wing,,,1637.3,https://www.poewiki.net/wiki/Moonbender%27s_Wing
+Topaz Ring,0.56%,179,50.00%,,2,Astral Projector,,,55.6,https://www.poewiki.net/wiki/Astral_Projector
+Topaz Ring,16.48%,7,50.00%,,4,Kikazaru,,,1637.3,https://www.poewiki.net/wiki/Kikazaru
+Topaz Ring,16.48%,7,50.00%,,4,Storm Secret,,,1637.3,https://www.poewiki.net/wiki/Storm_Secret
+Topaz Ring,16.48%,7,50.00%,,4,Valako's Sign,,,1637.3,https://www.poewiki.net/wiki/Valako%27s_Sign
+Tribal Circlet,50.00%,2,50.00%,,5,Mark of the Red Covenant,,,2076.4,https://www.poewiki.net/wiki/Mark_of_the_Red_Covenant
+Tricorne,7.87%,13,92.13%,,3,Fairgraves' Tricorne,,,314.8,https://www.poewiki.net/wiki/Fairgraves%27_Tricorne
+Triumphant Lamellar,40.93%,3,59.07%,,4,Cherrubim's Maleficence,,,1637.3,https://www.poewiki.net/wiki/Cherrubim%27s_Maleficence
+Turquoise Amulet,0.46%,218,50.00%,,2,Badge of the Brotherhood,,,55.6,https://www.poewiki.net/wiki/Badge_of_the_Brotherhood
+Turquoise Amulet,2.61%,39,50.00%,,3,Fury Valve,,,314.8,https://www.poewiki.net/wiki/Fury_Valve
+Turquoise Amulet,2.61%,39,50.00%,,3,Ungil's Harmony,,,314.8,https://www.poewiki.net/wiki/Ungil%27s_Harmony
+Turquoise Amulet,13.56%,8,50.00%,,4,Maligaro's Cruelty,,,1637.3,https://www.poewiki.net/wiki/Maligaro%27s_Cruelty
+Turquoise Amulet,13.56%,8,50.00%,,4,Warped Timepiece,,,1637.3,https://www.poewiki.net/wiki/Warped_Timepiece
+Turquoise Amulet,17.20%,6,50.00%,,5,Victario's Acuity,,,2076.4,https://www.poewiki.net/wiki/Victario%27s_Acuity
+Twilight Blade,50.00%,2,50.00%,,5,Prismatic Eclipse,,,2076.4,https://www.poewiki.net/wiki/Prismatic_Eclipse
+Two-Point Arrow Quiver,1.30%,77,50.00%,,2,Rigwald's Quills,,,55.6,https://www.poewiki.net/wiki/Rigwald%27s_Quills
+Two-Point Arrow Quiver,48.70%,3,50.00%,,5,Skirmish,,,2076.4,https://www.poewiki.net/wiki/Skirmish
+Two-Stone Ring,3.73%,27,50.00%,Cold/Lightning,3,Call of the Brotherhood,,,314.8,https://www.poewiki.net/wiki/Call_of_the_Brotherhood
+Two-Stone Ring,19.40%,6,50.00%,Cold/Lightning,4,Berek's Grip,,,1637.3,https://www.poewiki.net/wiki/Berek%27s_Grip
+Two-Stone Ring,3.73%,27,50.00%,Fire/Cold,3,Rigwald's Crest,,,314.8,https://www.poewiki.net/wiki/Rigwald%27s_Crest
+Two-Stone Ring,19.40%,6,50.00%,Fire/Cold,4,Berek's Pass,,,1637.3,https://www.poewiki.net/wiki/Berek%27s_Pass
+Two-Stone Ring,3.73%,27,50.00%,Fire/Lightning,3,Berek's Respite,,,314.8,https://www.poewiki.net/wiki/Berek%27s_Respite
+Two-Toned Boots,1.39%,72,95.83%,Cold/Lightning,2,Beacon of Madness,Chaos,,55.6,https://www.poewiki.net/wiki/Beacon_of_Madness
+Two-Toned Boots,1.39%,72,95.83%,Fire/Cold,2,Beacon of Madness,Double Damage,,55.6,https://www.poewiki.net/wiki/Beacon_of_Madness
+Two-Toned Boots,1.39%,72,95.83%,Fire/Lightning,2,Beacon of Madness,Elemental,,55.6,https://www.poewiki.net/wiki/Beacon_of_Madness
+Tyrant's Sekhem,50.00%,2,50.00%,,5,Sign of the Sin Eater,,,2076.4,https://www.poewiki.net/wiki/Sign_of_the_Sin_Eater
+Unset Ring,2.07%,49,50.00%,,3,The Hungry Loop,,,314.8,https://www.poewiki.net/wiki/The_Hungry_Loop
+Unset Ring,2.07%,49,50.00%,,3,Profane Proxy,,,314.8,https://www.poewiki.net/wiki/Profane_Proxy
+Unset Ring,10.75%,10,50.00%,,4,Essence Worm,,,1637.3,https://www.poewiki.net/wiki/Essence_Worm
+Unset Ring,10.75%,10,50.00%,,4,Malachai's Artifice,,,1637.3,https://www.poewiki.net/wiki/Malachai%27s_Artifice
+Unset Ring,10.75%,10,50.00%,,4,Voideye,,,1637.3,https://www.poewiki.net/wiki/Voideye
+Unset Ring,13.63%,8,50.00%,,5,Mark of Submission,,,2076.4,https://www.poewiki.net/wiki/Mark_of_Submission
+Ursine Pelt,50.00%,2,50.00%,,5,Rat's Nest,,,2076.4,https://www.poewiki.net/wiki/Rat%27s_Nest
+Vaal Axe,7.87%,13,92.13%,,3,Hezmana's Bloodlust,,,314.8,https://www.poewiki.net/wiki/Hezmana%27s_Bloodlust
+Vaal Blade,1.39%,72,90.74%,,2,Varunastra,,,55.6,https://www.poewiki.net/wiki/Varunastra
+Vaal Blade,7.87%,13,90.74%,,3,Rebuke of the Vaal,,,314.8,https://www.poewiki.net/wiki/Rebuke_of_the_Vaal
+Vaal Buckler,50.00%,2,50.00%,,5,Thousand Teeth Temu,,,2076.4,https://www.poewiki.net/wiki/Thousand_Teeth_Temu
+Vaal Claw,0.04%,2771,50.00%,,0,Essentia Sanguis,,,1.5,https://www.poewiki.net/wiki/Essentia_Sanguis
+Vaal Claw,49.96%,3,50.00%,,5,Allure,,,2076.4,https://www.poewiki.net/wiki/Allure
+Vaal Gauntlets,1.39%,72,98.61%,,2,Doryani's Fist,,,55.6,https://www.poewiki.net/wiki/Doryani%27s_Fist
+Vaal Hatchet,7.87%,13,92.13%,,3,"Jack, the Axe",,,314.8,"https://www.poewiki.net/wiki/Jack,_the_Axe"
+Vaal Mask,7.87%,13,92.13%,,3,Fractal Thoughts,,,314.8,https://www.poewiki.net/wiki/Fractal_Thoughts
+Vaal Regalia,40.93%,3,59.07%,,4,The Beast Fur Shawl,,,1637.3,https://www.poewiki.net/wiki/The_Beast_Fur_Shawl
+Vaal Sceptre,7.87%,13,92.13%,,3,Doon Cuebiyari,,,314.8,https://www.poewiki.net/wiki/Doon_Cuebiyari
+Vanguard Belt,40.93%,3,59.07%,,4,Perseverance,,,1637.3,https://www.poewiki.net/wiki/Perseverance
+Varnished Coat,7.87%,13,92.13%,,3,Carcass Jack,,,314.8,https://www.poewiki.net/wiki/Carcass_Jack
+Velvet Gloves,50.00%,2,50.00%,,5,Doedre's Tenure,,,2076.4,https://www.poewiki.net/wiki/Doedre%27s_Tenure
+Velvet Slippers,50.00%,2,50.00%,,5,Wondertrap,,,2076.4,https://www.poewiki.net/wiki/Wondertrap
+Vile Arrow Quiver,50.00%,2,50.00%,,5,Maloney's Nightfall,,,2076.4,https://www.poewiki.net/wiki/Maloney%27s_Nightfall
+Vile Staff,7.87%,13,92.13%,,3,The Whispering Ice,,,314.8,https://www.poewiki.net/wiki/The_Whispering_Ice
+Vine Circlet,50.00%,2,50.00%,,5,Crown of Thorns,,,2076.4,https://www.poewiki.net/wiki/Crown_of_Thorns
+Viridian Jewel,1.39%,72,91.66%,,2,Lioneye's Fall,,,55.6,https://www.poewiki.net/wiki/Lioneye%27s_Fall
+Viridian Jewel,1.39%,72,91.66%,,2,Ancestral Vision,,,55.6,https://www.poewiki.net/wiki/Ancestral_Vision
+Viridian Jewel,1.39%,72,91.66%,,2,Stormshroud,,,55.6,https://www.poewiki.net/wiki/Stormshroud
+Viridian Jewel,1.39%,72,91.66%,,2,Intuitive Leap,,,55.6,https://www.poewiki.net/wiki/Intuitive_Leap
+Viridian Jewel,1.39%,72,91.66%,,2,Pure Talent,,,55.6,https://www.poewiki.net/wiki/Pure_Talent
+Viridian Jewel,1.39%,72,91.66%,,2,Unnatural Instinct,,,55.6,https://www.poewiki.net/wiki/Unnatural_Instinct
+Visored Sallet,40.93%,3,59.07%,,4,The Trickster's Smile,,,1637.3,https://www.poewiki.net/wiki/The_Tricksters_Smile
+Void Axe,0.68%,148,99.32%,,1,Kitava's Feast,,,27.2,https://www.poewiki.net/wiki/Kitava%27s_Feast
+Void Sceptre,7.87%,13,84.26%,,3,Mon'tregul's Grasp,,,314.8,https://www.poewiki.net/wiki/Mon%27tregul%27s_Grasp
+Void Sceptre,7.87%,13,84.26%,,3,Augyre,,,314.8,https://www.poewiki.net/wiki/Augyre
+War Buckler,40.93%,3,59.07%,,4,Chalice of Horrors,,,1637.3,https://www.poewiki.net/wiki/Chalice_of_Horrors
+War Hammer,25.00%,4,50.00%,,5,Brightbeak,,,2076.4,https://www.poewiki.net/wiki/Brightbeak
+War Hammer,25.00%,4,50.00%,,5,Lavianga's Wisdom,,,2076.4,https://www.poewiki.net/wiki/Lavianga%27s_Wisdom
+War Sword,50.00%,2,50.00%,,5,The Tempestuous Steel,,,2076.4,https://www.poewiki.net/wiki/The_Tempestuous_Steel
+Whalebone Rapier,40.93%,3,59.07%,,4,The Goddess Bound,,,1637.3,https://www.poewiki.net/wiki/The_Goddess_Bound
+Widowsilk Robe,1.39%,72,90.74%,,2,Doedre's Skin,,,55.6,https://www.poewiki.net/wiki/Doedre%27s_Skin
+Widowsilk Robe,7.87%,13,90.74%,,3,Infernal Mantle,,,314.8,https://www.poewiki.net/wiki/Infernal_Mantle
+Wild Leather,50.00%,2,50.00%,,5,Foxshade,,,2076.4,https://www.poewiki.net/wiki/Foxshade
+Wolf Pelt,50.00%,2,50.00%,,5,Elevore,,,2076.4,https://www.poewiki.net/wiki/Elevore
+Woodsplitter,50.00%,2,50.00%,,5,Limbsplit,,,2076.4,https://www.poewiki.net/wiki/Limbsplit
+Wool Gloves,40.93%,3,59.07%,,4,Sadima's Touch,,,1637.3,https://www.poewiki.net/wiki/Sadima%27s_Touch
+Wool Shoes,50.00%,2,50.00%,,5,Wanderlust,,,2076.4,https://www.poewiki.net/wiki/Wanderlust
+Wrapped Mitts,50.00%,2,50.00%,,5,Ondar's Clasp,,,2076.4,https://www.poewiki.net/wiki/Ondar%27s_Clasp
+Wyrmscale Doublet,0.68%,148,99.32%,,1,Gruthkul's Pelt,,,27.2,https://www.poewiki.net/wiki/Gruthkul%27s_Pelt
+Wyrmscale Gauntlets,25.00%,4,50.00%,,4,Tanu Ahi,,,1637.3,https://www.poewiki.net/wiki/Tanu_Ahi
+Wyrmscale Gauntlets,25.00%,4,50.00%,,4,Wyrmsign,,,1637.3,https://www.poewiki.net/wiki/Wyrmsign
+Zealot Gloves,7.87%,13,76.39%,,3,Volkuur's Guidance,Lightning,,314.8,https://www.poewiki.net/wiki/Volkuur%27s_Guidance
+Zealot Gloves,7.87%,13,76.39%,,3,Volkuur's Guidance,Fire,,314.8,https://www.poewiki.net/wiki/Volkuur%27s_Guidance
+Zealot Gloves,7.87%,13,76.39%,,3,Volkuur's Guidance,Cold,,314.8,https://www.poewiki.net/wiki/Volkuur%27s_Guidance
+Zealot Helmet,40.93%,3,59.07%,,4,Kitava's Thirst,,,1637.3,https://www.poewiki.net/wiki/Kitava%27s_Thirst
+Zodiac Leather,1.39%,72,98.61%,,2,Hyrri's Ire,,,55.6,https://www.poewiki.net/wiki/Hyrri%27s_Ire


### PR DESCRIPTION
- Added League Highlight based on thresholds for Gwennen, Tujen and Ritual Windows.
- Added information about tier of uniques and chance to mythic corrupted items.
- Added an option to switch between displaying the chaos value of each Ritual Window item and its value when compared to a 1000 tribute to 1 chaos baseline.
