### PR TITLE
feat: show unit value and hint below threshold.

### DIFF
--- a/Ninja Price/Main/Render.cs
+++ b/Ninja Price/Main/Render.cs
@@ -615,7 +615,15 @@ public partial class Main
         {
             Graphics.DrawBox(drawBox, Settings.VisualPriceSettings.BackgroundColor);
             var textPosition = new Vector2(drawBox.Center.X, drawBox.Center.Y - ImGui.GetTextLineHeight() / 2);
-            Graphics.DrawText(item.PriceData.MinChaosValue.FormatNumber(Settings.VisualPriceSettings.SignificantDigits.Value), textPosition,
+
+            var itemValue = item.PriceData.MinChaosValue;
+            if (Settings.PriceOverlaySettings.ShowUnitValue)
+            {
+                itemValue /= item.CurrencyInfo.StackSize;
+                if (itemValue < Settings.PriceOverlaySettings.UnitValueHintThreshold) textColor = Color.Red;
+            }
+            
+            Graphics.DrawText(itemValue.FormatNumber(Settings.VisualPriceSettings.SignificantDigits.Value), textPosition,
                 textColor, FontAlign.Center);
         }
     }

--- a/Ninja Price/Settings/Settings.cs
+++ b/Ninja Price/Settings/Settings.cs
@@ -162,6 +162,10 @@ public class PriceOverlaySettings
     public ToggleNode DoNotDrawWhileAnItemIsHovered { get; set; } = new(false);
 
     public RangeNode<int> BoxHeight { get; set; } = new(15, 0, 100);
+    
+    public ToggleNode ShowUnitValue { get; set; } = new(false);
+    
+    public RangeNode<float> UnitValueHintThreshold { get; set; } = new(0.9f, 0, 100);
 }
 
 [Submenu(CollapsedByDefault = true)]


### PR DESCRIPTION
Hovering boxes, instead of showing full stack value, can be toggled to show unit value. With that you also receive color variation hints when unit value is below threshold. This feature aims to facilitate scarabs exhange but could also be customized.

<img width="778" height="838" alt="image" src="https://github.com/user-attachments/assets/b9d9e6d7-26b8-4865-8a31-641d9a2e130f" />
<img width="688" height="180" alt="image" src="https://github.com/user-attachments/assets/3a39c637-994b-4e3a-beb7-60eb5195b243" />
